### PR TITLE
feat: Add tags to listings for improved search relevance

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,137 +68,137 @@
                     <img class="service-favicon" src="https://www.chatgpt.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">ChatGPT</span>
                     <span class="service-url">https://www.chatgpt.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">chatgpt,openai,gpt,chat,ai assistant</span></a>
                 <a href="https://character.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://character.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Character AI</span>
                     <span class="service-url">https://character.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">character ai,character,chat,ai assistant,roleplay</span></a>
                 <a href="https://claude.ai/new" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://claude.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Claude</span>
                     <span class="service-url">https://claude.ai/new</span>
-                </a>
+<span class="service-tags" style="display:none;">claude,anthropic,chat,ai assistant</span></a>
                 <a href="https://sourcegraph.com/cody" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://sourcegraph.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Cody</span>
                     <span class="service-url">https://sourcegraph.com/cody</span>
-                </a>
+<span class="service-tags" style="display:none;">cody,sourcegraph,code,ai assistant,developer tool</span></a>
                 <a href="https://www.copy.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.copy.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Copy.ai</span>
                     <span class="service-url">https://www.copy.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">copy.ai,copywriting,writing,ai assistant</span></a>
                 <a href="https://chat.deepseek.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://deepseek.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">DeepSeek</span>
                     <span class="service-url">https://chat.deepseek.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">deepseek,chat,ai assistant</span></a>
                 <a href="https://gemini.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://gemini.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Gemini</span>
                     <span class="service-url">https://gemini.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google gemini,gemini,google,chat,ai assistant</span></a>
                 <a href="https://www.grok.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.grok.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Grok</span>
                     <span class="service-url">https://www.grok.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">grok,x,twitter,chat,ai assistant</span></a>
                 <a href="https://x.ai/api" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://x.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Grok API</span>
                     <span class="service-url">https://x.ai/api</span>
-                </a>
+<span class="service-tags" style="display:none;">grok,grok api,x,twitter,api,ai assistant</span></a>
                 <a href="https://x.ai/grok-voice" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://x.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Grok Voice</span>
                     <span class="service-url">https://x.ai/grok-voice</span>
-                </a>
+<span class="service-tags" style="display:none;">grok,grok voice,voice,x,twitter,ai assistant</span></a>
                 <a href="https://developers.inflection.ai/login" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://developers.inflection.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Inflection AI</span>
                     <span class="service-url">https://developers.inflection.ai/login</span>
-                </a>
+<span class="service-tags" style="display:none;">inflection ai,inflection,pi,chat,ai assistant,api</span></a>
                 <a href="https://www.intercom.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.intercom.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Intercom AI</span>
                     <span class="service-url">https://www.intercom.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">intercom ai,intercom,customer service,chat,ai assistant</span></a>
                 <a href="https://www.jasper.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.jasper.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Jasper</span>
                     <span class="service-url">https://www.jasper.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">jasper,jasper.ai,writing,content creation,ai assistant</span></a>
                 <a href="https://www.meta.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.meta.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Meta AI</span>
                     <span class="service-url">https://www.meta.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">meta ai,meta,facebook,chat,ai assistant</span></a>
                 <a href="https://copilot.microsoft.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://copilot.microsoft.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Microsoft Copilot</span>
                     <span class="service-url">https://copilot.microsoft.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">microsoft copilot,copilot,microsoft,bing chat,chat,ai assistant</span></a>
                 <a href="https://chat.minimax.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://chat.minimax.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Minimax Chat</span>
                     <span class="service-url">https://chat.minimax.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">minimax chat,minimax,chat,ai assistant</span></a>
                 <a href="https://chat.mistral.ai/chat" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://chat.mistral.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Mistral AI</span>
                     <span class="service-url">https://chat.mistral.ai/chat</span>
-                </a>
+<span class="service-tags" style="display:none;">mistral ai,mistral,le chat,chat,ai assistant</span></a>
                 <a href="https://www.notion.so/product/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.notion.so/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Notion AI</span>
                     <span class="service-url">https://www.notion.so/product/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">notion ai,notion,writing,productivity,ai assistant</span></a>
                 <a href="https://www.perplexity.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.perplexity.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Perplexity</span>
                     <span class="service-url">https://www.perplexity.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">perplexity,perplexity.ai,search,research,ai assistant</span></a>
                 <a href="https://poe.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://poe.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Poe</span>
                     <span class="service-url">https://poe.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">poe,quora,chat,multiple models,ai assistant</span></a>
                 <a href="https://chat.qwen.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://chat.qwen.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Qwen</span>
                     <span class="service-url">https://chat.qwen.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">qwen,alibaba,tongyi qianwen,chat,ai assistant</span></a>
                 <a href="https://rytr.me/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://rytr.me/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Rytr</span>
                     <span class="service-url">https://rytr.me/</span>
-                </a>
+<span class="service-tags" style="display:none;">rytr,rytr.me,writing,content creation,ai assistant</span></a>
                 <a href="https://www.sudowrite.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.sudowrite.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Sudowrite</span>
                     <span class="service-url">https://www.sudowrite.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">sudowrite,writing,fiction,storytelling,ai assistant</span></a>
                 <a href="https://writer.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://writer.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Writer.com</span>
                     <span class="service-url">https://writer.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">writer.com,writer,writing,content creation,ai assistant,enterprise</span></a>
                 <a href="https://writesonic.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://writesonic.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Writesonic</span>
                     <span class="service-url">https://writesonic.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">writesonic,writing,content creation,seo,ai assistant</span></a>
                 <a href="https://x.ai/chat" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://x.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">xAI Chat</span>
                     <span class="service-url">https://x.ai/chat</span>
-                </a>
+<span class="service-tags" style="display:none;">xai chat,xai,x,twitter,grok,chat,ai assistant</span></a>
                 <a href="https://www.zendesk.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.zendesk.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Zendesk AI</span>
                     <span class="service-url">https://www.zendesk.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">zendesk ai,zendesk,customer service,chat,ai assistant</span></a>
             </div>
         </section>
 
@@ -213,87 +213,87 @@
                     <img class="service-favicon" src="https://www.chatgpt.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">ChatGPT</span>
                     <span class="service-url">https://www.chatgpt.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">chatgpt,openai,gpt,image generation,dall-e,ai assistant</span></a>
                 <a href="https://www.adobe.com/products/firefly/landpa.html" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.adobe.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Adobe Firefly</span>
                     <span class="service-url">https://www.adobe.com/products/firefly/landpa.html</span>
-                </a>
+<span class="service-tags" style="display:none;">adobe firefly,adobe,firefly,image generation,design,generative fill</span></a>
                 <a href="https://www.artbreeder.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.artbreeder.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Artbreeder</span>
                     <span class="service-url">https://www.artbreeder.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">artbreeder,image generation,portraits,generative art,design</span></a>
                 <a href="https://www.canva.com/ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.canva.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Canva AI</span>
                     <span class="service-url">https://www.canva.com/ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">canva ai,canva,design,image editing,magic design</span></a>
                 <a href="https://www.craiyon.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.craiyon.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Craiyon</span>
                     <span class="service-url">https://www.craiyon.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">craiyon,dall-e mini,image generation</span></a>
                 <a href="https://www.d-id.com/pricing/studio/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.d-id.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">D-ID</span>
                     <span class="service-url">https://www.d-id.com/pricing/studio/</span>
-                </a>
+<span class="service-tags" style="display:none;">d-id,avatar,video generation,photorealistic</span></a>
                 <a href="https://openai.com/dall-e" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://openai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">DALL-E</span>
                     <span class="service-url">https://openai.com/dall-e</span>
-                </a>
+<span class="service-tags" style="display:none;">dall-e,openai,gpt,image generation</span></a>
                 <a href="https://davinci.ai/app" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://davinci.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">DaVinci AI</span>
                     <span class="service-url">https://davinci.ai/app</span>
-                </a>
+<span class="service-tags" style="display:none;">davinci ai,davinci,image generation,art</span></a>
                 <a href="https://www.fal.ai/flux" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.fal.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Flux</span>
                     <span class="service-url">https://www.fal.ai/flux</span>
-                </a>
+<span class="service-tags" style="display:none;">flux,fal.ai,image generation,video generation,real-time</span></a>
                 <a href="https://higgsfield.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://higgsfield.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Higgsfield AI</span>
                     <span class="service-url">https://higgsfield.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">higgsfield ai,higgsfield,video generation,personalization</span></a>
                 <a href="https://ideogram.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ideogram.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Ideogram</span>
                     <span class="service-url">https://ideogram.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">ideogram,ideogram.ai,image generation,typography,text in image</span></a>
                 <a href="https://app.leonardo.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://app.leonardo.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Leonardo AI</span>
                     <span class="service-url">https://app.leonardo.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">leonardo ai,leonardo,image generation,game assets,art</span></a>
                 <a href="https://designer.microsoft.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://designer.microsoft.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Microsoft Designer</span>
                     <span class="service-url">https://designer.microsoft.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">microsoft designer,microsoft,design,graphic design,image generation</span></a>
                 <a href="https://www.bing.com/images/create" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.bing.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Bing Image Creator</span>
                     <span class="service-url">https://bing.com/images/create</span>
-                </a>
+<span class="service-tags" style="display:none;">bing image creator,microsoft,bing,image generation,dall-e</span></a>
                 <a href="https://www.midjourney.com/explore?tab=top_month" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.midjourney.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">MidJourney</span>
                     <span class="service-url">https://www.midjourney.com/explore?tab=top_month</span>
-                </a>
+<span class="service-tags" style="display:none;">midjourney,image generation,art,discord</span></a>
                 <a href="https://nightcafe.studio/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://nightcafe.studio/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">NightCafe</span>
                     <span class="service-url">https://nightcafe.studio/</span>
-                </a>
+<span class="service-tags" style="display:none;">nightcafe,nightcafe studio,image generation,art,community</span></a>
                 <a href="https://stablediffusionweb.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://stablediffusionweb.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Stable Diffusion</span>
                     <span class="service-url">https://stablediffusionweb.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">stable diffusion,stablediffusionweb,image generation,open source</span></a>
             </div>
         </section>
 
@@ -308,77 +308,77 @@
                     <img class="service-favicon" src="https://www.capcut.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">CapCut</span>
                     <span class="service-url">https://www.capcut.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">capcut,video editing,mobile,desktop,bytedance</span></a>
                 <a href="https://clipchamp.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://clipchamp.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Clipchamp</span>
                     <span class="service-url">https://clipchamp.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">clipchamp,video editing,microsoft</span></a>
                 <a href="https://www.descript.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.descript.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Descript</span>
                     <span class="service-url">https://www.descript.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">descript,video editing,audio editing,transcription,podcasting</span></a>
                 <a href="https://hailuoai.video/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://hailuoai.video/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Hailuo AI</span>
                     <span class="service-url">https://hailuoai.video/</span>
-                </a>
+<span class="service-tags" style="display:none;">hailuo ai,hailuo,video generation,ai video</span></a>
                 <a href="https://hailuoai.video/subscribe" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://hailuoai.video/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Hailuo AI Subscribe</span>
                     <span class="service-url">https://hailuoai.video/subscribe</span>
-                </a>
+<span class="service-tags" style="display:none;">hailuo ai,hailuo,video generation,ai video,subscribe</span></a>
                 <a href="https://invideo.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://invideo.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Invideo AI</span>
                     <span class="service-url">https://invideo.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">invideo ai,invideo,video generation,ai video editor</span></a>
                 <a href="https://www.klingai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.klingai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Kling AI</span>
                     <span class="service-url">https://www.klingai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">kling ai,kling,video generation,kuaishou</span></a>
                 <a href="https://lumalabs.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://lumalabs.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Luma Labs</span>
                     <span class="service-url">https://lumalabs.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">luma labs,luma,3d generation,nerf,video generation,dream machine</span></a>
                 <a href="https://www.opus.pro/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.opus.pro/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Opus Clip</span>
                     <span class="service-url">https://www.opus.pro/</span>
-                </a>
+<span class="service-tags" style="display:none;">opus clip,opus.pro,video repurposing,short clips,ai video editing</span></a>
                 <a href="https://pika.art/login" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://pika.art/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Pika</span>
                     <span class="service-url">https://pika.art/login</span>
-                </a>
+<span class="service-tags" style="display:none;">pika,pika.art,video generation,video editing</span></a>
                 <a href="https://app.runwayml.com/login" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://app.runwayml.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">RunwayML</span>
                     <span class="service-url">https://app.runwayml.com/login</span>
-                </a>
+<span class="service-tags" style="display:none;">runwayml,runway,video generation,video editing,gen-1,gen-2</span></a>
                 <a href="https://sora.chatgpt.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://sora.chatgpt.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Sora</span>
                     <span class="service-url">https://sora.chatgpt.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">sora,openai,video generation,text-to-video</span></a>
                 <a href="https://www.synthesia.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.synthesia.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Synthesia</span>
                     <span class="service-url">https://www.synthesia.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">synthesia,synthesia.io,video generation,avatar,ai presenter</span></a>
                 <a href="https://deepmind.google/technologies/veo/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://deepmind.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Veo-2</span>
                     <span class="service-url">https://deepmind.google/technologies/veo/</span>
-                </a>
+<span class="service-tags" style="display:none;">veo-2,veo,google deepmind,video generation</span></a>
                 <a href="https://www.veed.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.veed.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Veed.io</span>
                     <span class="service-url">https://www.veed.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">veed.io,veed,video editing,online video editor</span></a>
             </div>
         </section>
 
@@ -393,72 +393,72 @@
                     <img class="service-favicon" src="https://www.aiva.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">AIVA</span>
                     <span class="service-url">https://www.aiva.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">aiva,aiva.ai,music generation,soundtrack,composition</span></a>
                 <a href="https://www.assemblyai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.assemblyai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">AssemblyAI</span>
                     <span class="service-url">https://www.assemblyai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">assemblyai,speech-to-text,transcription,api,audio intelligence</span></a>
                 <a href="https://elevenlabs.io/app/home" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://elevenlabs.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">ElevenLabs</span>
                     <span class="service-url">https://elevenlabs.io/app/home</span>
-                </a>
+<span class="service-tags" style="display:none;">elevenlabs,text-to-speech,voice generation,voice cloning,api</span></a>
                 <a href="https://app.landr.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://app.landr.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Landr</span>
                     <span class="service-url">https://app.landr.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">landr,music production,mastering,distribution</span></a>
                 <a href="https://mubert.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://mubert.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Mubert</span>
                     <span class="service-url">https://mubert.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">mubert,generative music,royalty-free music,api</span></a>
                 <a href="https://murf.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://murf.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Murf.ai</span>
                     <span class="service-url">https://murf.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">murf.ai,murf,text-to-speech,voice generation,voiceover</span></a>
                 <a href="https://play.ht/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://play.ht/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Play.ht</span>
                     <span class="service-url">https://play.ht/</span>
-                </a>
+<span class="service-tags" style="display:none;">play.ht,playht,text-to-speech,voice generation,api</span></a>
                 <a href="https://soundraw.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://soundraw.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Soundraw</span>
                     <span class="service-url">https://soundraw.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">soundraw,soundraw.io,music generation,royalty-free music</span></a>
                 <a href="https://suno.com/invite/@nathanneurotic" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://suno.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Suno</span>
                     <span class="service-url">https://suno.com/invite/@nathanneurotic</span>
-                </a>
+<span class="service-tags" style="display:none;">suno,suno.ai,music generation,song creation,lyrics</span></a>
                 <a href="https://suno.com/create?wid=default" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://suno.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Suno Create</span>
                     <span class="service-url">https://suno.com/create?wid=default</span>
-                </a>
+<span class="service-tags" style="display:none;">suno create,suno,suno.ai,music generation,song creation</span></a>
                 <a href="https://dreamtonics.com/synthesizerv/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://dreamtonics.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Synthesizer V</span>
                     <span class="service-url">https://dreamtonics.com/synthesizerv/</span>
-                </a>
+<span class="service-tags" style="display:none;">synthesizer v,synthv,voice synthesis,singing synthesis,dreamtonics</span></a>
                 <a href="https://www.udio.com/creators/NathanNeurotic" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.udio.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Udio</span>
                     <span class="service-url">https://www.udio.com/creators/NathanNeurotic</span>
-                </a>
+<span class="service-tags" style="display:none;">udio,udio.com,music generation,song creation</span></a>
                 <a href="https://www.udio.com/create" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.udio.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Udio Create</span>
                     <span class="service-url">https://www.udio.com/create</span>
-                </a>
+<span class="service-tags" style="display:none;">udio create,udio,udio.com,music generation,song creation</span></a>
                 <a href="https://www.voicemod.net/ai-voices/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.voicemod.net/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Voicemod AI Voices</span>
                     <span class="service-url">https://www.voicemod.net/ai-voices/</span>
-                </a>
+<span class="service-tags" style="display:none;">voicemod ai voices,voicemod,voice changer,real-time,text-to-song</span></a>
             </div>
         </section>
 
@@ -473,62 +473,62 @@
                     <img class="service-favicon" src="https://bolt.new/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Bolt.new</span>
                     <span class="service-url">https://bolt.new/</span>
-                </a>
+<span class="service-tags" style="display:none;">bolt.new,bolt,developer environment,cloud ide</span></a>
                 <a href="https://codeium.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://codeium.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Codeium</span>
                     <span class="service-url">https://codeium.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">codeium,coding,development,ai assistant,code completion,ide extension</span></a>
                 <a href="https://www.tabnine.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.tabnine.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Codota</span>
                     <span class="service-url">https://www.tabnine.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">codota,tabnine,coding,development,ai assistant,code completion,ide extension</span></a>
                 <a href="https://www.cursor.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.cursor.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Cursor</span>
                     <span class="service-url">https://www.cursor.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">cursor,ide,ai editor,coding,development</span></a>
                 <a href="https://www.snyk.io/deepcode/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.snyk.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">DeepCode</span>
                     <span class="service-url">https://www.snyk.io/deepcode/</span>
-                </a>
+<span class="service-tags" style="display:none;">deepcode,snyk,code analysis,security,code review</span></a>
                 <a href="https://github.com/features/copilot" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://github.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">GitHub Copilot</span>
                     <span class="service-url">https://github.com/features/copilot</span>
-                </a>
+<span class="service-tags" style="display:none;">github,copilot,coding,development,ai assistant,code completion,microsoft,openai</span></a>
                 <a href="https://github.com/copilot" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://github.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">GitHub Copilot Repo</span>
                     <span class="service-url">https://github.com/copilot</span>
-                </a>
+<span class="service-tags" style="display:none;">github,copilot,coding,development,ai assistant,code completion,microsoft,repository</span></a>
                 <a href="https://codeassist.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://codeassist.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Code Assist</span>
                     <span class="service-url">https://codeassist.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google code assist,google,coding,development,ai assistant,code completion,android studio</span></a>
              <a href="https://jules.google.com/" class="service-button" target="_blank">
                 <img class="service-favicon" src="https://jules.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Jules</span>
                     <span class="service-url">https://jules.google.com/</span>
-                    </a>
+                    <span class="service-tags" style="display:none;">jules,google,coding,development,ai assistant,code review</span></a>
                 <a href="https://www.phind.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.phind.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Phind</span>
                     <span class="service-url">https://www.phind.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">phind,search engine,developer search,ai search,coding,development</span></a>
                 <a href="https://www.qodex.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.qodex.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Qodex</span>
                     <span class="service-url">https://www.qodex.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">qodex,qodex.ai,code generation,coding,development</span></a>
                 <a href="https://replit.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://replit.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Replit</span>
                     <span class="service-url">https://replit.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">replit,ide,cloud ide,coding,development,collaboration</span></a>
             </div>
         </section>
 
@@ -543,92 +543,92 @@
                     <img class="service-favicon" src="https://www.beautiful.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Beautiful.ai</span>
                     <span class="service-url">https://www.beautiful.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">beautiful.ai,presentations,design,ai presentation maker</span></a>
                 <a href="https://www.duolingo.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.duolingo.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Duolingo AI</span>
                     <span class="service-url">https://www.duolingo.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">duolingo ai,duolingo,language learning,education,chat</span></a>
                 <a href="https://elicit.org/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://elicit.org/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Elicit</span>
                     <span class="service-url">https://elicit.org/</span>
-                </a>
+<span class="service-tags" style="display:none;">elicit,elicit.org,research,ai research assistant,papers</span></a>
                 <a href="https://gamma.app/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://gamma.app/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gamma.app</span>
                     <span class="service-url">https://gamma.app/</span>
-                </a>
+<span class="service-tags" style="display:none;">gamma.app,gamma,presentations,ai presentation maker,documents,webpages</span></a>
                 <a href="https://www.grammarly.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.grammarly.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Grammarly</span>
                     <span class="service-url">https://www.grammarly.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">grammarly,writing assistant,grammar check,spell check,ai writing</span></a>
                 <a href="https://huggingface.co/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://huggingface.co/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Hugging Face</span>
                     <span class="service-url">https://huggingface.co/</span>
-                </a>
+<span class="service-tags" style="display:none;">hugging face,huggingface,models,nlp,machine learning,open source</span></a>
                 <a href="https://dataplatform.cloud.ibm.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://dataplatform.cloud.ibm.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">IBM Watson</span>
                     <span class="service-url">https://dataplatform.cloud.ibm.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">ibm watson,ibm,ai platform,cloud ai,machine learning</span></a>
                 <a href="https://kahoot.com/ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://kahoot.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Kahoot! AI</span>
                     <span class="service-url">https://kahoot.com/ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">kahoot! ai,kahoot,education,quizzes,interactive learning</span></a>
                 <a href="https://www.kaggle.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.kaggle.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Kaggle</span>
                     <span class="service-url">https://www.kaggle.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">kaggle,data science,machine learning,competitions,datasets</span></a>
                 <a href="https://notebooklm.google/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://notebooklm.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">NotebookLM</span>
                     <span class="service-url">https://notebooklm.google/</span>
-                </a>
+<span class="service-tags" style="display:none;">notebooklm,google,research,note taking,ai assistant</span></a>
                 <a href="https://otio.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://otio.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Otio</span>
                     <span class="service-url">https://otio.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">otio,otio.ai,research,summarization,ai assistant</span></a>
                 <a href="https://otter.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://otter.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Otter.ai</span>
                     <span class="service-url">https://otter.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">otter.ai,otter,transcription,meeting notes,ai assistant</span></a>
                 <a href="https://quillbot.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://quillbot.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">QuillBot</span>
                     <span class="service-url">https://quillbot.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">quillbot,paraphrasing,summarizing,writing tool,grammar checker</span></a>
                 <a href="https://www.squirrelai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.squirrelai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Squirrel AI</span>
                     <span class="service-url">https://www.squirrelai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">squirrel ai,education,personalized learning,tutoring</span></a>
                 <a href="https://www.tableau.com/products/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.tableau.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Tableau AI</span>
                     <span class="service-url">https://www.tableau.com/products/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">tableau ai,tableau,data visualization,business intelligence,analytics</span></a>
                 <a href="https://www.wolframalpha.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.wolframalpha.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Wolfram Alpha</span>
                     <span class="service-url">https://www.wolframalpha.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">wolfram alpha,computational knowledge,search engine,mathematics,science</span></a>
                 <a href="https://you.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://you.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">YouChat</span>
                     <span class="service-url">https://you.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">youchat,you.com,search engine,chat,ai assistant</span></a>
                 <a href="https://zapier.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://zapier.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Zapier AI</span>
                     <span class="service-url">https://zapier.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">zapier ai,zapier,automation,workflow automation,ai assistant</span></a>
             </div>
         </section>
 
@@ -643,127 +643,127 @@
                     <img class="service-favicon" src="https://www.ai21.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">AI21 Labs</span>
                     <span class="service-url">https://www.ai21.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">ai21 labs,ai21,nlp,language models,api,developer platform</span></a>
                 <a href="https://aws.amazon.com/sagemaker/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://aws.amazon.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Amazon SageMaker</span>
                     <span class="service-url">https://aws.amazon.com/sagemaker/</span>
-                </a>
+<span class="service-tags" style="display:none;">amazon sagemaker,aws,sagemaker,machine learning,mlops,developer platform,cloud</span></a>
                 <a href="https://azure.microsoft.com/en-us/products/ai-services/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://azure.microsoft.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Azure AI Services</span>
                     <span class="service-url">https://azure.microsoft.com/en-us/products/ai-services/</span>
-                </a>
+<span class="service-tags" style="display:none;">azure ai services,microsoft azure,azure,ai platform,cloud ai,developer platform,api</span></a>
                 <a href="https://www.clarifai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.clarifai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Clarifai</span>
                     <span class="service-url">https://www.clarifai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">clarifai,computer vision,nlp,ai platform,api,developer platform</span></a>
                 <a href="https://cohere.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://cohere.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Cohere</span>
                     <span class="service-url">https://cohere.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">cohere,nlp,language models,api,developer platform,generative ai</span></a>
                 <a href="https://www.cortical.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.cortical.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Cortical</span>
                     <span class="service-url">https://www.cortical.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">cortical,cortical.io,nlp,natural language understanding,api</span></a>
                 <a href="https://www.datarobot.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.datarobot.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">DataRobot</span>
                     <span class="service-url">https://www.datarobot.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">datarobot,automl,machine learning platform,ai platform,enterprise ai</span></a>
                 <a href="https://www.databricks.com/product/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.databricks.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Databricks (Mosaic AI)</span>
                     <span class="service-url">https://www.databricks.com/product/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">databricks,mosaic ai,data lakehouse,machine learning platform,llmops</span></a>
                 <a href="https://developer.android.com/ai/gemini-nano" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://developer.android.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gemini Nano (Android)</span>
                     <span class="service-url">https://developer.android.com/ai/gemini-nano</span>
-                </a>
+<span class="service-tags" style="display:none;">gemini nano,google,android,on-device ai,mobile ai,developer platform,api</span></a>
                 <a href="https://ai.google.dev/gemini-api/docs?utm_source=gfd&utm_medium=referral&utm_campaign=ai_logo_garden&utm_content" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ai.google.dev/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gemini API Docs (Garden)</span>
                     <span class="service-url">https://ai.google.dev/gemini-api/docs?utm_source=gfd&utm_medium=referral&utm_campaign=ai_logo_garden&utm_content</span>
-                </a>
+<span class="service-tags" style="display:none;">gemini api,google,api,developer platform,garden,documentation</span></a>
                 <a href="https://aistudio.google.com/prompts/new_chat" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://aistudio.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google AI Studio</span>
                     <span class="service-url">https://aistudio.google.com/prompts/new_chat</span>
-                </a>
+<span class="service-tags" style="display:none;">google ai studio,google,makerนนite,prototyping,gemini,developer tool,api</span></a>
                 <a href="https://aistudio.google.com/app/prompts/new_chat?utm_source=gfd&utm_medium=referral&utm_campaign=home_garden&utm_content=" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://aistudio.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google AI Studio (Garden)</span>
                     <span class="service-url">https://aistudio.google.com/app/prompts/new_chat?utm_source=gfd&utm_medium=referral&utm_campaign=home_garden&utm_content=</span>
-                </a>
+<span class="service-tags" style="display:none;">google ai studio,google,makerนนite,prototyping,gemini,developer tool,api,garden</span></a>
                 <a href="https://ai.google.dev/edge" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ai.google.dev/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google AI Edge</span>
                     <span class="service-url">https://ai.google.dev/edge</span>
-                </a>
+<span class="service-tags" style="display:none;">google ai edge,google,on-device ai,edge computing,developer platform,api</span></a>
                 <a href="https://shell.cloud.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://shell.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Cloud Shell</span>
                     <span class="service-url">https://shell.cloud.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google cloud shell,google cloud,gcp,cli,developer tool,cloud ide</span></a>
                 <a href="https://console.cloud.google.com/products/solutions/catalog?inv=1&invt=Aby_hw&project=engaged-timing-jxcbk" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Cloud Solutions Catalog</span>
                     <span class="service-url">https://console.cloud.google.com/products/solutions/catalog?inv=1&invt=Aby_hw&project=engaged-timing-jxcbk</span>
-                </a>
+<span class="service-tags" style="display:none;">google cloud solutions catalog,gcp,google cloud,solutions,developer platform</span></a>
                 <a href="https://developers.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://developers.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Developers</span>
                     <span class="service-url">https://developers.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google developers,google,api,documentation,developer tools</span></a>
                  <a href="https://console.home.google.com/projects?pli=1" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.home.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Home Projects Console</span>
                     <span class="service-url">https://console.home.google.com/projects?pli=1</span>
-                </a>
+<span class="service-tags" style="display:none;">google home projects console,google home,smart home,iot,developer console,api</span></a>
                 <a href="https://labs.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://labs.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Labs</span>
                     <span class="service-url">https://labs.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google labs,google,experimental,ai experiments,research</span></a>
                 <a href="https://console.cloud.google.com/vertex-ai/studio/overview" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Vertex AI</span>
                     <span class="service-url">https://console.cloud.google.com/vertex-ai/studio/overview</span>
-                </a>
+<span class="service-tags" style="display:none;">google vertex ai,google cloud,gcp,machine learning,ai platform,mlops,api</span></a>
                 <a href="https://console.cloud.google.com/vertex-ai/studio/overview?inv=1&invt=Aby_kQ&project=engaged-timing-jxcbk" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Vertex AI Studio (Engaged)</span>
                     <span class="service-url">https://console.cloud.google.com/vertex-ai/studio/overview?inv=1&invt=Aby_kQ&project=engaged-timing-jxcbk</span>
-                </a>
+<span class="service-tags" style="display:none;">google vertex ai studio,google cloud,gcp,machine learning,ai platform,mlops,api,engaged</span></a>
                 <a href="https://www.hume.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.hume.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Hume AI</span>
                     <span class="service-url">https://www.hume.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">hume ai,hume,emotion ai,empathic ai,api,voice ai</span></a>
                 <a href="https://www.minimax.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.minimax.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Minimax</span>
                     <span class="service-url">https://www.minimax.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">minimax,minimax.io,llm,api,developer platform,chat</span></a>
                 <a href="https://ollama.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ollama.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Ollama</span>
                     <span class="service-url">https://ollama.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">ollama,llm,local llm,open source,developer tool,api</span></a>
                 <a href="https://www.salesforce.com/products/ai-cloud/overview/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.salesforce.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Salesforce Einstein / AI Cloud</span>
                     <span class="service-url">https://www.salesforce.com/products/ai-cloud/overview/</span>
-                </a>
+<span class="service-tags" style="display:none;">salesforce einstein,salesforce,ai cloud,crm ai,enterprise ai,api</span></a>
                 <a href="https://stability.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://stability.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Stability AI</span>
                     <span class="service-url">https://stability.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">stability ai,stable diffusion,image generation,video generation,audio generation,llm,api,developer platform,open source</span></a>
             </div>
         </section>
 
@@ -778,147 +778,147 @@
                     <img class="service-favicon" src="https://gemini.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Gemini</span>
                     <span class="service-url">https://gemini.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google gemini,gemini,google,chat,ai assistant,multimodal</span></a>
                 <a href="https://gemini.google.com/app" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://gemini.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Gemini App</span>
                     <span class="service-url">https://gemini.google.com/app</span>
-                </a>
+<span class="service-tags" style="display:none;">google gemini app,gemini,google,mobile app,ai assistant</span></a>
                 <a href="https://deepmind.google/technologies/veo/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://deepmind.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Veo-2</span>
                     <span class="service-url">https://deepmind.google/technologies/veo/</span>
-                </a>
+<span class="service-tags" style="display:none;">veo-2,veo,google,deepmind,video generation</span></a>
                 <a href="https://codeassist.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://codeassist.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Code Assist</span>
                     <span class="service-url">https://codeassist.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google code assist,google,coding,development,ai assistant,code completion,android studio,ide</span></a>
              <a href="https://jules.google.com/" class="service-button" target="_blank">
                 <img class="service-favicon" src="https://jules.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Jules</span>
                     <span class="service-url">https://jules.google.com/</span>
-                    </a>
+                    <span class="service-tags" style="display:none;">jules,google,coding,development,ai assistant,code review,ide</span></a>
                 <a href="https://notebooklm.google/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://notebooklm.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">NotebookLM</span>
                     <span class="service-url">https://notebooklm.google/</span>
-                </a>
+<span class="service-tags" style="display:none;">notebooklm,google,research,note taking,ai assistant,gemini</span></a>
                 <a href="https://developer.android.com/ai/gemini-nano" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://developer.android.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gemini Nano (Android)</span>
                     <span class="service-url">https://developer.android.com/ai/gemini-nano</span>
-                </a>
+<span class="service-tags" style="display:none;">gemini nano,google,android,on-device ai,mobile ai,developer platform,api,gemini</span></a>
                 <a href="https://ai.google.dev/gemini-api/docs?utm_source=gfd&utm_medium=referral&utm_campaign=ai_logo_garden&utm_content" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ai.google.dev/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gemini API Docs (Garden)</span>
                     <span class="service-url">https://ai.google.dev/gemini-api/docs?utm_source=gfd&utm_medium=referral&utm_campaign=ai_logo_garden&utm_content</span>
-                </a>
+<span class="service-tags" style="display:none;">gemini api,google,api,developer platform,garden,documentation,gemini</span></a>
                 <a href="https://aistudio.google.com/prompts/new_chat" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://aistudio.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google AI Studio</span>
                     <span class="service-url">https://aistudio.google.com/prompts/new_chat</span>
-                </a>
+<span class="service-tags" style="display:none;">google ai studio,google,makerนนite,prototyping,gemini,developer tool,api,ai</span></a>
                 <a href="https://aistudio.google.com/app/prompts/new_chat?utm_source=gfd&utm_medium=referral&utm_campaign=home_garden&utm_content=" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://aistudio.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google AI Studio (Garden)</span>
                     <span class="service-url">https://aistudio.google.com/app/prompts/new_chat?utm_source=gfd&utm_medium=referral&utm_campaign=home_garden&utm_content=</span>
-                </a>
+<span class="service-tags" style="display:none;">google ai studio,google,makerนนite,prototyping,gemini,developer tool,api,garden,ai</span></a>
                 <a href="https://ai.google.dev/edge" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ai.google.dev/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google AI Edge</span>
                     <span class="service-url">https://ai.google.dev/edge</span>
-                </a>
+<span class="service-tags" style="display:none;">google ai edge,google,on-device ai,edge computing,developer platform,api,ai</span></a>
                 <a href="https://shell.cloud.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://shell.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Cloud Shell</span>
                     <span class="service-url">https://shell.cloud.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google cloud shell,google cloud,gcp,cli,developer tool,cloud ide,vm</span></a>
                 <a href="https://console.cloud.google.com/products/solutions/catalog?inv=1&invt=Aby_hw&project=engaged-timing-jxcbk" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Cloud Solutions Catalog</span>
                     <span class="service-url">https://console.cloud.google.com/products/solutions/catalog?inv=1&invt=Aby_hw&project=engaged-timing-jxcbk</span>
-                </a>
+<span class="service-tags" style="display:none;">google cloud solutions catalog,gcp,google cloud,solutions,developer platform,marketplace</span></a>
                 <a href="https://developers.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://developers.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Developers</span>
                     <span class="service-url">https://developers.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google developers,google,api,documentation,developer tools,sdk</span></a>
                  <a href="https://console.home.google.com/projects?pli=1" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.home.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Home Projects Console</span>
                     <span class="service-url">https://console.home.google.com/projects?pli=1</span>
-                </a>
+<span class="service-tags" style="display:none;">google home projects console,google home,smart home,iot,developer console,api,actions on google</span></a>
                 <a href="https://labs.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://labs.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Labs</span>
                     <span class="service-url">https://labs.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google labs,google,experimental,ai experiments,research,innovation</span></a>
                 <a href="https://console.cloud.google.com/vertex-ai/studio/overview" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Vertex AI</span>
                     <span class="service-url">https://console.cloud.google.com/vertex-ai/studio/overview</span>
-                </a>
+<span class="service-tags" style="display:none;">google vertex ai,google cloud,gcp,machine learning,ai platform,mlops,api,ai</span></a>
                 <a href="https://console.cloud.google.com/vertex-ai/studio/overview?inv=1&invt=Aby_kQ&project=engaged-timing-jxcbk" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://console.cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Vertex AI Studio (Engaged)</span>
                     <span class="service-url">https://console.cloud.google.com/vertex-ai/studio/overview?inv=1&invt=Aby_kQ&project=engaged-timing-jxcbk</span>
-                </a>
+<span class="service-tags" style="display:none;">google vertex ai studio,google cloud,gcp,machine learning,ai platform,mlops,api,engaged,ai</span></a>
                 <a href="https://ai.google/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ai.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">AI Google</span>
                     <span class="service-url">https://ai.google/</span>
-                </a>
+<span class="service-tags" style="display:none;">ai google,google ai,google,research,products,artificial intelligence</span></a>
                 <a href="https://cloud.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://cloud.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Cloud</span>
                     <span class="service-url">https://cloud.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google cloud,gcp,cloud computing,developer platform,api,ai,machine learning</span></a>
                 <a href="https://code.google.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://code.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Code</span>
                     <span class="service-url">https://code.google.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">google code,google,developer tools,archive,open source</span></a>
                 <a href="https://code.google.com/archive/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://code.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Code Archive</span>
                     <span class="service-url">https://code.google.com/archive/</span>
-                </a>
+<span class="service-tags" style="display:none;">google code archive,google,developer tools,archive,open source,legacy</span></a>
                 <a href="https://deepmind.google/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://deepmind.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google DeepMind</span>
                     <span class="service-url">https://deepmind.google/</span>
-                </a>
+<span class="service-tags" style="display:none;">google deepmind,deepmind,google,research,ai,machine learning,alphago,alphazero</span></a>
                 <a href="https://labs.google/about" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://labs.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Labs About</span>
                     <span class="service-url">https://labs.google/about</span>
-                </a>
+<span class="service-tags" style="display:none;">google labs,google,experimental,ai experiments,research,about</span></a>
                 <a href="https://labs.google.com/experiments" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://labs.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Labs Experiments</span>
                     <span class="service-url">https://labs.google.com/experiments</span>
-                </a>
+<span class="service-tags" style="display:none;">google labs experiments,google,experimental,ai experiments,research,search</span></a>
                 <a href="https://labs.google.com/search/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://labs.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Labs Search</span>
                     <span class="service-url">https://labs.google.com/search/</span>
-                </a>
+<span class="service-tags" style="display:none;">google labs search,google,experimental,ai experiments,research,search</span></a>
                 <a href="https://labs.google.com/sessions" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://labs.google.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Labs Sessions</span>
                     <span class="service-url">https://labs.google.com/sessions</span>
-                </a>
+<span class="service-tags" style="display:none;">google labs sessions,google,experimental,ai experiments,research,events</span></a>
                 <a href="https://opensource.google/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://opensource.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Open Source</span>
                     <span class="service-url">https://opensource.google/</span>
-                </a>
+<span class="service-tags" style="display:none;">google open source,google,open source,developer tools,software</span></a>
                 <a href="https://research.google/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://research.google/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Google Research</span>
                     <span class="service-url">https://research.google/</span>
-                </a>
+<span class="service-tags" style="display:none;">google research,google,research,ai,machine learning,publications</span></a>
             </div>
         </section>
 
@@ -933,42 +933,42 @@
                     <img class="service-favicon" src="https://www.aidoc.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Aidoc</span>
                     <span class="service-url">https://www.aidoc.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">aidoc,healthcare,medical imaging,radiology,ai diagnosis</span></a>
                 <a href="https://www.deepmind.com/health" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.deepmind.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">DeepMind Health</span>
                     <span class="service-url">https://www.deepmind.com/health</span>
-                </a>
+<span class="service-tags" style="display:none;">deepmind health,google deepmind,google,healthcare,medical research,ai diagnosis</span></a>
                 <a href="https://www.merative.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.merative.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Merative</span>
                     <span class="service-url">https://www.merative.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">merative,healthcare data,analytics,formerly ibm watson health</span></a>
                 <a href="https://www.pathai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.pathai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">PathAI</span>
                     <span class="service-url">https://www.pathai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">pathai,pathology,ai diagnosis,cancer research,drug development</span></a>
                 <a href="https://www.tempus.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.tempus.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Tempus</span>
                     <span class="service-url">https://www.tempus.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">tempus,genomic data,precision medicine,cancer care,data analytics</span></a>
                 <a href="https://www.viz.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.viz.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Viz.ai</span>
                     <span class="service-url">https://www.viz.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">viz.ai,stroke detection,care coordination,medical imaging,healthcare</span></a>
                 <a href="https://www.welltok.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.welltok.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Welltok</span>
                     <span class="service-url">https://www.welltok.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">welltok,consumer health,patient engagement,healthcare analytics</span></a>
                 <a href="https://www.xpertdox.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.xpertdox.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">XpertDox</span>
                     <span class="service-url">https://www.xpertdox.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">xpertdox,clinical decision support,medical search,healthcare</span></a>
             </div>
         </section>
 
@@ -983,37 +983,37 @@
                     <img class="service-favicon" src="https://www.casetext.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Casetext</span>
                     <span class="service-url">https://www.casetext.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">casetext,legal research,ai legal assistant,brief analysis,legal tech</span></a>
                 <a href="https://www.clio.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.clio.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Clio</span>
                     <span class="service-url">https://www.clio.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">clio,legal software,law practice management,legal tech,ai</span></a>
                 <a href="https://www.everlaw.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.everlaw.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Everlaw</span>
                     <span class="service-url">https://www.everlaw.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">everlaw,ediscovery,legal tech,litigation,document review,ai</span></a>
                 <a href="https://www.harvey.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.harvey.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Harvey</span>
                     <span class="service-url">https://www.harvey.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">harvey,harvey.ai,legal ai,legal automation,legal tech,ai</span></a>
                 <a href="https://ironcladapp.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://ironcladapp.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Ironclad</span>
                     <span class="service-url">https://ironcladapp.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">ironclad,contract management,clm,legal tech,ai</span></a>
                 <a href="https://www.lawgeex.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.lawgeex.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Lawgeex</span>
                     <span class="service-url">https://www.lawgeex.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">lawgeex,contract review,legal tech,ai</span></a>
                 <a href="https://www.nexlaw.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.nexlaw.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">NexLaw</span>
                     <span class="service-url">https://www.nexlaw.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">nexlaw,nexlaw.ai,legal practice management,legal tech,ai</span></a>
             </div>
         </section>
 
@@ -1028,37 +1028,37 @@
                     <img class="service-favicon" src="https://kasisto.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Kasisto</span>
                     <span class="service-url">https://kasisto.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">kasisto,conversational ai,financial services,chatbot,fintech</span></a>
                 <a href="https://www.klarna.com/ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.klarna.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Klarna AI</span>
                     <span class="service-url">https://www.klarna.com/ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">klarna ai,klarna,fintech,buy now pay later,shopping,ai assistant</span></a>
                 <a href="https://personetics.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://personetics.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Personetics</span>
                     <span class="service-url">https://personetics.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">personetics,financial data,personalization,banking,fintech,ai</span></a>
                 <a href="https://plaid.com/ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://plaid.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Plaid AI</span>
                     <span class="service-url">https://plaid.com/ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">plaid ai,plaid,open banking,financial data,api,fintech,ai</span></a>
                 <a href="https://stripe.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://stripe.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Stripe AI</span>
                     <span class="service-url">https://stripe.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">stripe ai,stripe,payments,fraud detection,fintech,ai</span></a>
                 <a href="https://www.upstart.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.upstart.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Upstart</span>
                     <span class="service-url">https://www.upstart.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">upstart,lending,loan origination,fintech,ai underwriting</span></a>
                 <a href="https://www.wealthfront.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.wealthfront.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Wealthfront</span>
                     <span class="service-url">https://www.wealthfront.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">wealthfront,robo-advisor,investment management,fintech,ai</span></a>
             </div>
         </section>
 
@@ -1073,37 +1073,37 @@
                     <img class="service-favicon" src="https://www.convai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Convai</span>
                     <span class="service-url">https://www.convai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">convai,gaming,game development,npc,ai characters,conversational ai</span></a>
                 <a href="https://www.flawlessai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.flawlessai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Flawless AI</span>
                     <span class="service-url">https://www.flawlessai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">flawless ai,visual dubbing,lip sync,film,gaming,ai</span></a>
                 <a href="https://www.inworld.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.inworld.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Inworld AI</span>
                     <span class="service-url">https://www.inworld.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">inworld ai,gaming,game development,npc,ai characters,character engine</span></a>
                 <a href="https://lumalabs.ai/genie" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://lumalabs.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Luma AI Genie</span>
                     <span class="service-url">https://lumalabs.ai/genie</span>
-                </a>
+<span class="service-tags" style="display:none;">luma ai genie,luma labs,3d model generation,text-to-3d,gaming,game development</span></a>
                 <a href="https://www.prometheanai.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.prometheanai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Promethean AI</span>
                     <span class="service-url">https://www.prometheanai.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">promethean ai,game development,level design,virtual worlds,ai assistant</span></a>
                 <a href="https://www.rosebud.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.rosebud.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Rosebud AI</span>
                     <span class="service-url">https://www.rosebud.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">rosebud ai,game assets,sprite generation,gaming,ai</span></a>
                 <a href="https://www.scenario.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.scenario.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Scenario</span>
                     <span class="service-url">https://www.scenario.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">scenario,game assets,image generation,gaming,ai content creation</span></a>
             </div>
         </section>
 
@@ -1118,27 +1118,27 @@
                     <img class="service-favicon" src="https://www.3daistudio.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">3D AI Studio</span>
                     <span class="service-url">https://www.3daistudio.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">3d ai studio,3d modeling,text-to-3d,image-to-3d,ai</span></a>
                 <a href="https://www.kaedim3d.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.kaedim3d.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Kaedim</span>
                     <span class="service-url">https://www.kaedim3d.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">kaedim,kaedim3d,2d-to-3d,3d modeling,game assets,ai</span></a>
                 <a href="https://www.meshy.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.meshy.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Meshy</span>
                     <span class="service-url">https://www.meshy.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">meshy,meshy.ai,text-to-3d,3d modeling,texturing,ai,cg</span></a>
                 <a href="https://huggingface.co/spaces/hysts/Shap-E" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://openai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Shap-E</span>
                     <span class="service-url">https://huggingface.co/spaces/hysts/Shap-E</span>
-                </a>
+<span class="service-tags" style="display:none;">shap-e,openai,text-to-3d,3d model generation,hugging face,point cloud</span></a>
                 <a href="https://huggingface.co/spaces/User-2468/point-e" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://openai.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Point-E</span>
                     <span class="service-url">https://huggingface.co/spaces/User-2468/point-e</span>
-                </a>
+<span class="service-tags" style="display:none;">point-e,openai,text-to-3d,3d model generation,point cloud,hugging face</span></a>
             </div>
         </section>
 
@@ -1153,22 +1153,22 @@
                     <img class="service-favicon" src="https://www.agrivi.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">AGRIVI</span>
                     <span class="service-url">https://www.agrivi.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">agrivi,agriculture,agritech,farming,farm management,ai</span></a>
                 <a href="https://www.cattleeye.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.cattleeye.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">CattleEye</span>
                     <span class="service-url">https://www.cattleeye.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">cattleeye,livestock monitoring,agriculture,agritech,ai,cattle</span></a>
                 <a href="https://www.itcagr.com/krishi-mitra" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.itcagr.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Krishi Mitra</span>
                     <span class="service-url">https://www.itcagr.com/krishi-mitra</span>
-                </a>
+<span class="service-tags" style="display:none;">krishi mitra,itc,agriculture,agritech,india,farming,ai</span></a>
                 <a href="https://robovision.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://robovision.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Robovision</span>
                     <span class="service-url">https://robovision.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">robovision,computer vision,agriculture,agritech,ai,robotics</span></a>
             </div>
         </section>
 
@@ -1183,17 +1183,17 @@
                     <img class="service-favicon" src="https://amadeus.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Amadeus AI</span>
                     <span class="service-url">https://amadeus.com/en/solutions/artificial-intelligence</span>
-                </a>
+<span class="service-tags" style="display:none;">amadeus ai,amadeus,travel technology,airlines,hospitality,ai</span></a>
                 <a href="https://www.hopper.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.hopper.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Hopper</span>
                     <span class="service-url">https://www.hopper.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">hopper,travel,flights,hotels,price prediction,ai</span></a>
                 <a href="https://www.tripadvisor.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.tripadvisor.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Tripadvisor AI</span>
                     <span class="service-url">https://www.tripadvisor.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">tripadvisor ai,tripadvisor,travel planning,reviews,recommendations,ai</span></a>
             </div>
         </section>
 
@@ -1208,17 +1208,17 @@
                     <img class="service-favicon" src="https://www.fourkites.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">FourKites</span>
                     <span class="service-url">https://www.fourkites.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">fourkites,supply chain visibility,logistics,real-time tracking,ai</span></a>
                 <a href="https://locus.sh/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://locus.sh/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Locus.sh</span>
                     <span class="service-url">https://locus.sh/</span>
-                </a>
+<span class="service-tags" style="display:none;">locus.sh,locus,logistics,route optimization,delivery management,ai</span></a>
                 <a href="https://www.shippeo.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.shippeo.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Shippeo</span>
                     <span class="service-url">https://www.shippeo.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">shippeo,supply chain visibility,logistics,real-time tracking,transportation,ai</span></a>
             </div>
         </section>
 
@@ -1233,17 +1233,17 @@
                     <img class="service-favicon" src="https://www.algolia.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Algolia</span>
                     <span class="service-url">https://www.algolia.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">algolia,search api,site search,ecommerce,ai search,retail</span></a>
                 <a href="https://www.dynamicyield.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.dynamicyield.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Dynamic Yield</span>
                     <span class="service-url">https://www.dynamicyield.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">dynamic yield,personalization,customer experience,retail,ecommerce,ai</span></a>
                 <a href="https://www.nexla.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.nexla.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Nexla</span>
                     <span class="service-url">https://www.nexla.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">nexla,data integration,data engineering,retail analytics,ai</span></a>
             </div>
         </section>
 
@@ -1258,12 +1258,12 @@
                     <img class="service-favicon" src="https://www.enelx.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Enel X</span>
                     <span class="service-url">https://www.enelx.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">enel x,energy,smart energy,demand response,ev charging,ai</span></a>
                 <a href="https://www.stem.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.stem.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Stem AI</span>
                     <span class="service-url">https://www.stem.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">stem ai,stem,energy storage,ai powered analytics,energy</span></a>
             </div>
         </section>
 
@@ -1278,12 +1278,12 @@
                     <img class="service-favicon" src="https://www.climate.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">ClimateAI</span>
                     <span class="service-url">https://www.climate.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">climateai,climate ai,climate risk,agriculture,supply chain,ai</span></a>
                 <a href="https://www.pachama.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.pachama.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Pachama</span>
                     <span class="service-url">https://www.pachama.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">pachama,carbon offsetting,forest monitoring,satellite data,ai,climate</span></a>
             </div>
         </section>
 
@@ -1298,67 +1298,67 @@
                     <img class="service-favicon" src="https://sora.chatgpt.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Sora</span>
                     <span class="service-url">https://sora.chatgpt.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">sora,openai,video generation,text-to-video,specialized</span></a>
                 <a href="https://www.darktrace.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.darktrace.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Darktrace</span>
                     <span class="service-url">https://www.darktrace.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">darktrace,cybersecurity,ai threat detection,network security,specialized</span></a>
                 <a href="https://fireflies.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://fireflies.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Fireflies.ai</span>
                     <span class="service-url">https://fireflies.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">fireflies.ai,fireflies,meeting transcription,ai meeting assistant,note taking,specialized</span></a>
                 <a href="https://www.gloat.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.gloat.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gloat</span>
                     <span class="service-url">https://www.gloat.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">gloat,talent marketplace,workforce agility,hr tech,ai,specialized</span></a>
                 <a href="https://www.gong.io/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.gong.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Gong.io</span>
                     <span class="service-url">https://www.gong.io/</span>
-                </a>
+<span class="service-tags" style="display:none;">gong.io,gong,revenue intelligence,sales analytics,conversation intelligence,ai,specialized</span></a>
                 <a href="https://www.hailo.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.hailo.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Hailo</span>
                     <span class="service-url">https://www.hailo.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">hailo,hailo.ai,ai processors,edge ai,hardware,deep learning,specialized</span></a>
                 <a href="https://www.lemonade.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.lemonade.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Lemonade</span>
                     <span class="service-url">https://www.lemonade.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">lemonade,insurtech,insurance,ai claims,specialized</span></a>
                 <a href="https://powerautomate.microsoft.com/en-us/ai-builder/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://powerautomate.microsoft.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Microsoft Power Automate (with AI Builder)</span>
                     <span class="service-url">https://powerautomate.microsoft.com/en-us/ai-builder/</span>
-                </a>
+<span class="service-tags" style="display:none;">microsoft power automate,power automate,ai builder,microsoft,rpa,automation,workflow,specialized</span></a>
                 <a href="https://www.opendoor.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.opendoor.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Opendoor AI</span>
                     <span class="service-url">https://www.opendoor.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">opendoor ai,opendoor,real estate,ibuyer,property valuation,ai,specialized</span></a>
                 <a href="https://www.roofstock.com/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.roofstock.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Roofstock</span>
                     <span class="service-url">https://www.roofstock.com/</span>
-                </a>
+<span class="service-tags" style="display:none;">roofstock,real estate investing,property technology,fintech,ai,specialized</span></a>
                 <a href="https://www.sportradar.com/ai" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.sportradar.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Sportradar AI</span>
                     <span class="service-url">https://www.sportradar.com/ai</span>
-                </a>
+<span class="service-tags" style="display:none;">sportradar ai,sportradar,sports data,analytics,betting,ai,specialized</span></a>
                 <a href="https://www.vellum.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.vellum.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Vellum</span>
                     <span class="service-url">https://www.vellum.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">vellum,vellum.ai,llm development,prompt engineering,api,specialized</span></a>
                 <a href="https://www.zesty.ai/" class="service-button" target="_blank">
                     <img class="service-favicon" src="https://www.zesty.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
                     <span class="service-name">Zesty.ai</span>
                     <span class="service-url">https://www.zesty.ai/</span>
-                </a>
+<span class="service-tags" style="display:none;">zesty.ai,zesty,property risk,insurance,climate risk,ai,specialized</span></a>
             </div>
         </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -34,7 +34,13 @@ document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('.service-button').forEach(button => {
             const name = button.querySelector('.service-name').textContent.toLowerCase();
             const url = button.querySelector('.service-url').textContent.toLowerCase();
-            button.style.display = (name.includes(query) || url.includes(query)) ? 'flex' : 'none';
+            const tagsSpan = button.querySelector('.service-tags');
+            let tagsMatch = false;
+            if (tagsSpan && tagsSpan.textContent) {
+                const tagsArray = tagsSpan.textContent.toLowerCase().split(',').map(tag => tag.trim());
+                tagsMatch = tagsArray.some(tag => tag.includes(query));
+            }
+            button.style.display = (name.includes(query) || url.includes(query) || tagsMatch) ? 'flex' : 'none';
         });
     });
 });


### PR DESCRIPTION
This commit introduces a tagging system to the AI service listings to enhance search functionality.

Key changes:

- Modified `index.html`:
    - Added a hidden `<span>` with the class `service-tags` to each service button (`<a>` tag).
    - Populated these spans with comma-separated keywords relevant to each service, such as 'openai', 'gpt', 'chat', 'api', as well as terms derived from the service's name, URL, and category.

- Updated `script.js`:
    - The search input event listener now also retrieves and parses the content of the `service-tags` span for each listing.
    - Search results will now appear if your query matches the service name, URL, or any of its associated tags.

This change aims to make the search more flexible and relevant, allowing you to find services using a broader range of keywords. Conceptual testing of the updated search logic and tagging data indicates the system works as intended.