### PR TITLE
Add 34 new AI tools to the 3D Modeling category

### DIFF
--- a/index.html
+++ b/index.html
@@ -1195,6 +1195,210 @@
                     <span class="service-name">Point-E</span>
                     <span class="service-url">https://huggingface.co/spaces/User-2468/point-e</span>
 <span class="service-tags" style="display:none;">point-e,openai,text-to-3d,3d model generation,point cloud,hugging face</span></a>
+                <a href="https://www.tripo3d.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.tripo3d.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Tripo3D</span>
+                    <span class="service-url">https://www.tripo3d.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, image-to-3d, generative ai</span>
+                </a>
+                <a href="https://deepai.org/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://deepai.org/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">DeepAI</span>
+                    <span class="service-url">https://deepai.org/</span>
+                    <span class="service-tags" style="display:none;">ai tools, api, image generation, text generation, nlp</span>
+                </a>
+                <a href="https://aitwo.co/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://aitwo.co/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">AITwo</span>
+                    <span class="service-url">https://aitwo.co/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, generative ai, text-to-3d</span>
+                </a>
+                <a href="https://www.vondy.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.vondy.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Vondy</span>
+                    <span class="service-url">https://www.vondy.com/</span>
+                    <span class="service-tags" style="display:none;">ai tools, productivity, content creation, platform</span>
+                </a>
+                <a href="https://www.alpha3d.io/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.alpha3d.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Alpha3D</span>
+                    <span class="service-url">https://www.alpha3d.io/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, ar, vr, generative ai</span>
+                </a>
+                <a href="https://www.instant3d.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.instant3d.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Instant3D</span>
+                    <span class="service-url">https://www.instant3d.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, image-to-3d, video-to-3d, generative ai</span>
+                </a>
+                <a href="https://luw.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://luw.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Luw AI</span>
+                    <span class="service-url">https://luw.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, generative ai</span>
+                </a>
+                <a href="https://trellis3d.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://trellis3d.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Trellis3D</span>
+                    <span class="service-url">https://trellis3d.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, procedural generation, game development</span>
+                </a>
+                <a href="https://picassoia.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://picassoia.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">PicassoIA</span>
+                    <span class="service-url">https://picassoia.com/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, image-to-3d</span>
+                </a>
+                <a href="https://research.nvidia.com/labs/dir/magic3d/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://research.nvidia.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">NVIDIA Magic3D</span>
+                    <span class="service-url">https://research.nvidia.com/labs/dir/magic3d/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, research, nvidia</span>
+                </a>
+                <a href="https://dreamfusion3d.github.io/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://dreamfusion3d.github.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">DreamFusion3D</span>
+                    <span class="service-url">https://dreamfusion3d.github.io/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, research, google</span>
+                </a>
+                <a href="https://www.threedee.design/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.threedee.design/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">ThreeDee Design</span>
+                    <span class="service-url">https://www.threedee.design/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, generative ai, design tool</span>
+                </a>
+                <a href="https://figuro.io/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://figuro.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Figuro</span>
+                    <span class="service-url">https://figuro.io/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, online 3d creator, design tool</span>
+                </a>
+                <a href="https://www.bing.com/images/create?&ctype=video#" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.bing.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Bing Video Creator</span>
+                    <span class="service-url">https://www.bing.com/images/create?&ctype=video#</span>
+                    <span class="service-tags" style="display:none;">video generation, ai, bing, microsoft, image-to-video</span>
+                </a>
+                <a href="https://www.bing.com/images/create?&ctype=image#" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.bing.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Bing Image Creator</span>
+                    <span class="service-url">https://www.bing.com/images/create?&ctype=image#</span>
+                    <span class="service-tags" style="display:none;">image generation, ai, bing, microsoft, dall-e</span>
+                </a>
+                <a href="https://edworking.com/ai-tools/3d-model-generator" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://edworking.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Edworking 3D Model Generator</span>
+                    <span class="service-url">https://edworking.com/ai-tools/3d-model-generator</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, edworking</span>
+                </a>
+                <a href="https://live3d.io/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://live3d.io/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Live3D</span>
+                    <span class="service-url">https://live3d.io/</span>
+                    <span class="service-tags" style="display:none;">vtuber software, avatar, motion capture, live streaming</span>
+                </a>
+                <a href="https://cgdream.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://cgdream.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">CGDream.ai</span>
+                    <span class="service-url">https://cgdream.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, generative ai</span>
+                </a>
+                <a href="https://pixcap.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://pixcap.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Pixcap</span>
+                    <span class="service-url">https://pixcap.com/</span>
+                    <span class="service-tags" style="display:none;">3d design, ai, 3d assets, graphic design</span>
+                </a>
+                <a href="https://ai3dmodelgenerator.net/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://ai3dmodelgenerator.net/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">AI 3D Model Generator</span>
+                    <span class="service-url">https://ai3dmodelgenerator.net/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, generative ai</span>
+                </a>
+                <a href="https://creati.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://creati.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Creati.ai</span>
+                    <span class="service-url">https://creati.ai/</span>
+                    <span class="service-tags" style="display:none;">ai tools, content creation, image generation, text generation</span>
+                </a>
+                <a href="https://www.backflip.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.backflip.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Backflip AI</span>
+                    <span class="service-url">https://www.backflip.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, video-to-3d, photogrammetry</span>
+                </a>
+                <a href="https://mazingxr.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://mazingxr.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">MazingXR</span>
+                    <span class="service-url">https://mazingxr.com/</span>
+                    <span class="service-tags" style="display:none;">ar, vr, 3d presentation, metaverse</span>
+                </a>
+                <a href="https://www.promeai.pro/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.promeai.pro/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">PromeAI</span>
+                    <span class="service-url">https://www.promeai.pro/</span>
+                    <span class="service-tags" style="display:none;">image generation, video generation, 3d rendering, ai, design tool</span>
+                </a>
+                <a href="https://www.masterpiecex.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.masterpiecex.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Masterpiece X</span>
+                    <span class="service-url">https://www.masterpiecex.com/</span>
+                    <span class="service-tags" style="display:none;">3d creation, ai, game development, metaverse</span>
+                </a>
+                <a href="https://www.csm.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.csm.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">CSM AI</span>
+                    <span class="service-url">https://www.csm.ai/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, image-to-3d, generative ai, game assets</span>
+                </a>
+                <a href="https://stability.ai/stable-3d" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://stability.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Stable 3D</span>
+                    <span class="service-url">https://stability.ai/stable-3d</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, image-to-3d, stability ai</span>
+                </a>
+                <a href="https://hyper3d.ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://hyper3d.ai/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Hyper3D</span>
+                    <span class="service-url">https://hyper3d.ai/</span>
+                    <span class="service-tags" style="display:none;">3d scanning, ai, image-to-3d, photogrammetry</span>
+                </a>
+                <a href="https://www.vidu.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.vidu.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Vidu</span>
+                    <span class="service-url">https://www.vidu.com/</span>
+                    <span class="service-tags" style="display:none;">video generation, ai, text-to-video</span>
+                </a>
+                <a href="https://3daimaker.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://3daimaker.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">3DAIMaker</span>
+                    <span class="service-url">https://3daimaker.com/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, image-to-3d</span>
+                </a>
+                <a href="https://www.figma.com/ai/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.figma.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Figma AI</span>
+                    <span class="service-url">https://www.figma.com/ai/</span>
+                    <span class="service-tags" style="display:none;">design tool, ui, ux, ai, diagramming, whiteboarding</span>
+                </a>
+                <a href="https://www.d5render.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://www.d5render.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">D5 Render</span>
+                    <span class="service-url">https://www.d5render.com/</span>
+                    <span class="service-tags" style="display:none;">3d rendering, architecture, real-time rendering, ray tracing</span>
+                </a>
+                <a href="https://hunyuan3-d.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://hunyuan3-d.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Hunyuan3D</span>
+                    <span class="service-url">https://hunyuan3-d.com/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, tencent</span>
+                </a>
+                <a href="https://3d.hunyuan.tencent.com/" class="service-button" target="_blank">
+                    <img class="service-favicon" src="https://3d.hunyuan.tencent.com/favicon.ico" onerror="this.src='./favicon.ico'" alt="Service favicon">
+                    <span class="service-name">Tencent Hunyuan3D</span>
+                    <span class="service-url">https://3d.hunyuan.tencent.com/</span>
+                    <span class="service-tags" style="display:none;">3d modeling, ai, text-to-3d, tencent, research</span>
+                </a>
             </div>
         </section>
 


### PR DESCRIPTION
This commit adds a comprehensive list of 34 new services to the '🔮 3D Modeling AI' section of the AI Services Dashboard.

The additions include a variety of tools ranging from text-to-3D generators, image-to-3D converters, research projects, and established platforms in the 3D and AI space.

Each new entry includes:
- A direct link to the service.
- The service name.
- A link to its favicon (with a fallback to a default icon).
- Relevant tags for searchability, such as '3d modeling', 'ai', 'text-to-3d', 'generative ai', etc.

Duplicates from the initial request list were removed, and URLs that were not direct tools (e.g., stock photo pages, general aggregator sites) were excluded. Some general company URLs were replaced with more specific tool/product page URLs (e.g., for Stability AI and Edworking).