### PR TITLE
Add Jest test for toggleCategory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Follow these instructions to get a local copy of the AI Services Dashboard up an
 3.  **Open the site:**
     Simply open the `index.html` file in your web browser. No special server is needed as it's a static website.
 
+### Running Tests
+
+If you have Node.js installed, you can run the unit tests with:
+
+```bash
+npm test
+```
+
+This uses Jest with `jsdom` to verify basic functionality in `script.js`.
+
 ## Modifying the Site
 
 The AI Services Dashboard is built with standard HTML, CSS, and JavaScript. Here's a brief overview of the file structure and how to make common modifications:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-services-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('toggleCategory', () => {
+  let window, document, header, content, chevron;
+
+  beforeEach(() => {
+    const html = `
+      <section class="category" id="test">
+        <h2 aria-expanded="false">Title <span class="chevron">▼</span></h2>
+        <div class="category-content"></div>
+      </section>
+    `;
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    window = dom.window;
+    document = window.document;
+    header = document.querySelector('h2');
+    content = document.querySelector('.category-content');
+    chevron = document.querySelector('.chevron');
+
+    // Inject the script into the JSDOM context
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('toggles open class and localStorage state', () => {
+    expect(content.classList.contains('open')).toBe(false);
+    expect(chevron.classList.contains('open')).toBe(false);
+    expect(window.localStorage.getItem('category-test')).toBe(null);
+
+    window.toggleCategory(header);
+
+    expect(content.classList.contains('open')).toBe(true);
+    expect(chevron.classList.contains('open')).toBe(true);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(window.localStorage.getItem('category-test')).toBe('open');
+
+    window.toggleCategory(header);
+
+    expect(content.classList.contains('open')).toBe(false);
+    expect(chevron.classList.contains('open')).toBe(false);
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(window.localStorage.getItem('category-test')).toBe('closed');
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with jsdom
- add a basic unit test for `toggleCategory`
- describe how to run tests in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443267b2248321ac2cde404513bd7f