### PR TITLE
Add search filtering unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ If you have Node.js installed, you can run the unit tests with:
 npm test
 ```
 
-This uses Jest with `jsdom` to verify basic functionality in `script.js`.
+This uses Jest with `jsdom` to verify functionality in `script.js`.
+The tests cover category toggling and the search filtering behavior.
 
 ## Modifying the Site
 

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('search filtering', () => {
+  let window, document, searchInput;
+
+  beforeEach(() => {
+    const html = `
+      <div class="search-container">
+        <input id="searchInput" type="text" />
+      </div>
+      <section class="category" id="cat1">
+        <h2>Category 1</h2>
+        <div class="category-content">
+          <a class="service-button">
+            <span class="service-name">Alpha</span>
+            <span class="service-url">http://alpha.com</span>
+          </a>
+          <a class="service-button">
+            <span class="service-name">Beta</span>
+            <span class="service-url">http://beta.com</span>
+          </a>
+        </div>
+      </section>
+      <section class="category" id="cat2">
+        <h2>Category 2</h2>
+        <div class="category-content">
+          <a class="service-button">
+            <span class="service-name">Gamma</span>
+            <span class="service-url">http://gamma.com</span>
+          </a>
+        </div>
+      </section>
+    `;
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    window.setupSearch();
+    searchInput = document.getElementById('searchInput');
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('filters services and categories based on query', () => {
+    const buttons = document.querySelectorAll('.service-button');
+    const [alphaBtn, betaBtn, gammaBtn] = buttons;
+    const cat1 = document.getElementById('cat1');
+    const cat2 = document.getElementById('cat2');
+
+    searchInput.value = 'alpha';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    expect(alphaBtn.style.display).toBe('flex');
+    expect(betaBtn.style.display).toBe('none');
+    expect(gammaBtn.style.display).toBe('none');
+    expect(cat1.style.display).toBe('');
+    expect(cat2.style.display).toBe('none');
+
+    searchInput.value = '';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    buttons.forEach(btn => expect(btn.style.display).toBe('flex'));
+    expect(cat1.style.display).toBe('');
+    expect(cat2.style.display).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- test search filtering in jsdom
- mention new test coverage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844379423b0832180760cdf482635c2