### PR TITLE
Sort services alphabetically

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,6 +43,7 @@ async function loadServices() {
         // Generate HTML for categories and services
         for (const categoryName in categories) {
             const servicesInCategory = categories[categoryName];
+            servicesInCategory.sort((a, b) => a.name.localeCompare(b.name));
             const categoryId = categoryName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 
             const categorySection = document.createElement('section');

--- a/tests/alphabetical.test.js
+++ b/tests/alphabetical.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('loadServices sorts services alphabetically', () => {
+  test('services in each category are ordered by name', async () => {
+    const html = '<main></main>';
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    const { window } = dom;
+    const { document } = window;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const sampleServices = [
+      { name: 'Beta', url: 'http://beta.com', category: 'Category 1' },
+      { name: 'Alpha', url: 'http://alpha.com', category: 'Category 1' },
+      { name: 'Gamma', url: 'http://gamma.com', category: 'Category 2' }
+    ];
+
+    window.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(sampleServices)
+    }));
+
+    await window.loadServices();
+
+    const names = [...document.querySelectorAll('#category-1 .service-name')].map(el => el.textContent);
+    expect(names).toEqual(['Alpha', 'Beta']);
+  });
+});


### PR DESCRIPTION
## Summary
- sort services alphabetically in each category before rendering
- add Jest test verifying alphabetical order

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684439f46d048321b017d69afd4199bb