### PR TITLE
Ensure alphabetical categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,8 +40,9 @@ async function loadServices() {
             return acc;
         }, {});
 
-        // Generate HTML for categories and services
-        for (const categoryName in categories) {
+        // Generate HTML for categories and services in alphabetical order
+        const sortedCategoryNames = Object.keys(categories).sort();
+        for (const categoryName of sortedCategoryNames) {
             const servicesInCategory = categories[categoryName];
             const categoryId = categoryName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 

--- a/tests/loadServices.test.js
+++ b/tests/loadServices.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('loadServices', () => {
+  let window, document, dom;
+
+  beforeEach(async () => {
+    const html = `<main></main>`;
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const servicesData = [
+      { name: 'One', url: 'http://one.com', favicon_url: 'one.ico', category: 'Banana' },
+      { name: 'Two', url: 'http://two.com', favicon_url: 'two.ico', category: 'Apple' }
+    ];
+
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(servicesData) })
+    );
+
+    await window.loadServices();
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('renders categories alphabetically', () => {
+    const sections = document.querySelectorAll('.category');
+    expect(sections[0].id).toBe('apple');
+    expect(sections[1].id).toBe('banana');
+  });
+
+  test('localStorage key uses category id', () => {
+    const firstHeader = document.querySelector('.category h2');
+    window.toggleCategory(firstHeader);
+    expect(window.localStorage.getItem('category-apple')).toBe('open');
+  });
+});


### PR DESCRIPTION
## Summary
- sort categories in `loadServices`
- test that dynamic categories are alphabetically ordered and IDs/localStorage work

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443a3323508321b50a0497a21043d7