### PR TITLE
Fix dynamic favicon alt text

### DIFF
--- a/script.js
+++ b/script.js
@@ -78,7 +78,7 @@ async function loadServices() {
                 serviceButton.target = '_blank';
 
                 const favicon = document.createElement('img');
-                favicon.alt = 'Service favicon';
+                favicon.alt = `${service.name} favicon`;
                 favicon.className = 'service-favicon';
                 favicon.src = service.favicon_url || './favicon.ico'; // Fallback favicon
                 favicon.onerror = () => { favicon.src = './favicon.ico'; }; // Handle broken favicons


### PR DESCRIPTION
## Summary
- set alt text on favicons to include the service name

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443ca37c688321b40499af7fed3689