### PR TITLE
Add Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Follow these instructions to get a local copy of the AI Services Dashboard up an
 
 *   A modern web browser (e.g., Chrome, Firefox, Safari, Edge).
 *   Git for cloning the repository (optional, you can also download the source code as a ZIP file).
+*   Node.js 18+ (recommended if you plan to run the tests).
 
 ### Installation & Local Setup
 
@@ -48,7 +49,7 @@ Follow these instructions to get a local copy of the AI Services Dashboard up an
 
 ### Running Tests
 
-If you have Node.js installed, first install the dev dependencies:
+If you have Node.js 18 or later installed, first install the dev dependencies:
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ai-services-dashboard",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- recommend Node.js 18+ in README prerequisites and testing instructions
- specify supported engines in package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443ce0fb5c83219177bf80b453c6db