### PR TITLE
Remove trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The AI Services Dashboard is built with standard HTML, CSS, and JavaScript. Here
 
 *   `index.html`: Mostly static HTML structure of the dashboard. Service listings are dynamically injected from `services.json` by `script.js`.
 *   `styles.css`: The primary stylesheet responsible for the visual appearance, layout, and retro theme of the site.
-*   `script.js`: Handles the typing effect, category toggling, search filtering, persistence of category states, and populates the page with data from `services.json`. 
+*   `script.js`: Handles the typing effect, category toggling, search filtering, persistence of category states, and populates the page with data from `services.json`.
 *   `services.json`: Stores the AI service data used to populate the dashboard.
 *   `favicon.ico`: Site icon.
 *   `README.md`: This file – providing information about the project.


### PR DESCRIPTION
## Summary
- fix stray space after `script.js` line in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844461aa73c8321b37dabdcd65f856d