### PR TITLE
Add rel noopener for service links

### DIFF
--- a/script.js
+++ b/script.js
@@ -76,6 +76,7 @@ async function loadServices() {
                 serviceButton.className = 'service-button';
                 serviceButton.href = service.url;
                 serviceButton.target = '_blank';
+                serviceButton.rel = 'noopener noreferrer';
 
                 const favicon = document.createElement('img');
                 favicon.alt = `${service.name} favicon`;


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to service buttons when opening in new tab

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444934c9848321a597a0894e882440