### PR TITLE
Enable keyboard toggling of sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -54,6 +54,13 @@ async function loadServices() {
             const categoryHeader = document.createElement('h2');
             categoryHeader.setAttribute('aria-expanded', 'false');
             categoryHeader.onclick = () => toggleCategory(categoryHeader); // Use arrow function to ensure 'this' context or pass element directly
+            categoryHeader.tabIndex = 0;
+            categoryHeader.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleCategory(categoryHeader);
+                }
+            });
 
             // Extract emoji and text for category title
             const emojiMatch = categoryName.match(/^(\p{Emoji_Presentation}|\p{Emoji})\s*/u);

--- a/tests/loadServices.test.js
+++ b/tests/loadServices.test.js
@@ -43,4 +43,16 @@ describe('loadServices', () => {
     window.toggleCategory(firstHeader);
     expect(window.localStorage.getItem('category-apple')).toBe('open');
   });
+
+  test('pressing Enter toggles the category', () => {
+    const firstHeader = document.querySelector('.category h2');
+    const content = firstHeader.nextElementSibling;
+
+    expect(content.classList.contains('open')).toBe(false);
+
+    const event = new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    firstHeader.dispatchEvent(event);
+
+    expect(content.classList.contains('open')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- make category headers keyboard focusable
- allow Enter or Space to toggle categories
- test keyboard interaction for categories

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444946abe88321a679a98e0c1a9945