### PR TITLE
Add tags and duplicate categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,10 +104,19 @@ async function loadServices() {
                 // For now, service.tags is not in services.json, so this will be hidden or empty
                 const serviceTagsSpan = document.createElement('span');
                 serviceTagsSpan.className = 'service-tags';
-                serviceTagsSpan.style.display = 'none'; // Hidden as per original structure
+                serviceTagsSpan.style.display = 'none';
+
+                let tags = [];
                 if (service.tags && Array.isArray(service.tags)) {
-                     serviceTagsSpan.textContent = service.tags.join(',');
+                    tags = service.tags.slice();
                 }
+
+                const catText = categoryName.replace(/^(\p{Emoji_Presentation}|\p{Emoji})\s*/u, '').trim();
+                if (!tags.includes(catText)) {
+                    tags.push(catText);
+                }
+
+                serviceTagsSpan.textContent = tags.join(',');
 
 
                 serviceButton.appendChild(favicon);

--- a/services.json
+++ b/services.json
@@ -285,7 +285,15 @@
         "name": "Claude",
         "url": "https://claude.ai/new",
         "favicon_url": "https://claude.ai/favicon.ico",
-        "category": "👽 All-in-One"
+        "category": "👽 All-in-One",
+        "tags": ["chatbot", "anthropic"]
+    },
+    {
+        "name": "Claude",
+        "url": "https://claude.ai/new",
+        "favicon_url": "https://claude.ai/favicon.ico",
+        "category": "💻 Coding and Development",
+        "tags": ["chatbot", "anthropic"]
     },
     {
         "name": "Cody",
@@ -1275,7 +1283,15 @@
         "name": "Hugging Face",
         "url": "https://huggingface.co/",
         "favicon_url": "https://huggingface.co/favicon.ico",
-        "category": "🔍 Research and Data Analysis"
+        "category": "🔍 Research and Data Analysis",
+        "tags": ["models", "datasets", "transformers"]
+    },
+    {
+        "name": "Hugging Face",
+        "url": "https://huggingface.co/",
+        "favicon_url": "https://huggingface.co/favicon.ico",
+        "category": "🌐 Developer Platforms and APIs",
+        "tags": ["models", "datasets", "transformers"]
     },
     {
         "name": "IBM Watson",

--- a/styles.css
+++ b/styles.css
@@ -131,26 +131,26 @@ main {
 .service-button {
     display: flex;
     flex-direction: column;
-    background: linear-gradient(135deg, rgba(10, 10, 10, 0.9), rgba(26, 42, 26, 0.9));
+    background: linear-gradient(135deg, rgba(20, 20, 20, 0.9), rgba(40, 60, 40, 0.9));
     padding: 1rem;
-    border: 2px solid #66b266;
+    border: 2px solid #5faa6f;
     border-radius: 15px;
     text-decoration: none;
-    color: #66b266;
-    box-shadow: inset 0 0 3px rgba(102, 178, 102, 0.3), 0 0 3px rgba(102, 178, 102, 0.2);
+    color: #5faa6f;
+    box-shadow: inset 0 0 3px rgba(95, 170, 111, 0.3), 0 0 3px rgba(95, 170, 111, 0.2);
     animation: pulse 2s infinite;
     transition: box-shadow 0.3s ease, transform 0.2s ease;
 }
 
 .service-button:hover {
-    box-shadow: inset 0 0 5px rgba(102, 178, 102, 0.5), 0 0 8px rgba(102, 178, 102, 0.3);
+    box-shadow: inset 0 0 5px rgba(95, 170, 111, 0.5), 0 0 8px rgba(95, 170, 111, 0.3);
     transform: translateY(-2px);
     animation: none;
 }
 
 @keyframes pulse {
-    0%, 100% { box-shadow: inset 0 0 3px rgba(102, 178, 102, 0.3), 0 0 3px rgba(102, 178, 102, 0.2); }
-    50% { box-shadow: inset 0 0 5px rgba(102, 178, 102, 0.5), 0 0 5px rgba(102, 178, 102, 0.3); }
+    0%, 100% { box-shadow: inset 0 0 3px rgba(95, 170, 111, 0.3), 0 0 3px rgba(95, 170, 111, 0.2); }
+    50% { box-shadow: inset 0 0 5px rgba(95, 170, 111, 0.5), 0 0 5px rgba(95, 170, 111, 0.3); }
 }
 
 .service-favicon {
@@ -171,6 +171,10 @@ main {
 .service-url {
     font-size: 1rem;
     word-break: break-all;
+}
+
+.service-tags {
+    display: none;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- duplicate services when they belong to multiple categories
- add optional `tags` array for richer searching
- include category names in the tags list automatically
- adjust service button colors to differentiate from page background

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844505f167883219c28175f352a0797