### PR TITLE
Add optional tags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ The AI Services Dashboard is built with standard HTML, CSS, and JavaScript. Here
 Service data is stored in `services.json`. To add a new service or update an existing one:
 
 1.  Open `services.json` in a text editor.
-2.  Add or edit an object in the JSON array with the fields `name`, `url`, `favicon_url`, and `category`.
+2.  Add or edit an object in the JSON array with the fields `name`, `url`, `favicon_url`, and `category`. You can also optionally include a `tags` array for improved search results.
     ```json
     {
         "name": "Example Service",
         "url": "https://example.com/",
         "favicon_url": "https://example.com/favicon.ico",
-        "category": "My Category"
+        "category": "My Category",
+        "tags": ["example", "demo"]
     }
     ```
     Ensure the new entry follows the same format as shown above.

--- a/script.js
+++ b/script.js
@@ -100,11 +100,11 @@ async function loadServices() {
                 serviceUrlSpan.className = 'service-url';
                 serviceUrlSpan.textContent = service.url;
 
-                // Add service tags if they exist in your services.json (assuming they might be added later)
-                // For now, service.tags is not in services.json, so this will be hidden or empty
+                // Add service tags if provided. These are also used for search
+                // functionality. Always include the category text as a hidden
+                // tag so services can be found by their category name.
                 const serviceTagsSpan = document.createElement('span');
                 serviceTagsSpan.className = 'service-tags';
-                serviceTagsSpan.style.display = 'none';
 
                 let tags = [];
                 if (service.tags && Array.isArray(service.tags)) {
@@ -117,6 +117,12 @@ async function loadServices() {
                 }
 
                 serviceTagsSpan.textContent = tags.join(',');
+                // Only display tags when the service actually defines some.
+                if (service.tags && Array.isArray(service.tags) && service.tags.length > 0) {
+                    serviceTagsSpan.style.display = 'inline';
+                } else {
+                    serviceTagsSpan.style.display = 'none';
+                }
 
 
                 serviceButton.appendChild(favicon);

--- a/services.json
+++ b/services.json
@@ -3,13 +3,15 @@
         "name": "3D AI Studio",
         "url": "https://www.3daistudio.com/",
         "favicon_url": "https://www.3daistudio.com/favicon.ico",
-        "category": "🔮 3D Modeling"
+        "category": "🔮 3D Modeling",
+        "tags": ["modeling", "design"]
     },
     {
         "name": "3DAIMaker",
         "url": "https://3daimaker.com/",
         "favicon_url": "https://3daimaker.com/favicon.ico",
-        "category": "🔮 3D Modeling"
+        "category": "🔮 3D Modeling",
+        "tags": ["creator"]
     },
     {
         "name": "AI 3D Model Generator",
@@ -419,7 +421,8 @@
         "name": "Writer.com",
         "url": "https://writer.com/",
         "favicon_url": "https://writer.com/favicon.ico",
-        "category": "👽 All-in-One"
+        "category": "👽 All-in-One",
+        "tags": ["writing"]
     },
     {
         "name": "Writesonic",
@@ -1651,7 +1654,8 @@
         "name": "Writer.com",
         "url": "https://writer.com/",
         "favicon_url": "https://writer.com/favicon.ico",
-        "category": "📚 Articles and Reviews"
+        "category": "📚 Articles and Reviews",
+        "tags": ["writing"]
     },
     {
         "name": "Writesonic",

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -16,10 +16,12 @@ describe('search filtering', () => {
           <a class="service-button">
             <span class="service-name">Alpha</span>
             <span class="service-url">http://alpha.com</span>
+            <span class="service-tags">news,cat1</span>
           </a>
           <a class="service-button">
             <span class="service-name">Beta</span>
             <span class="service-url">http://beta.com</span>
+            <span class="service-tags">support</span>
           </a>
         </div>
       </section>
@@ -29,6 +31,7 @@ describe('search filtering', () => {
           <a class="service-button">
             <span class="service-name">Gamma</span>
             <span class="service-url">http://gamma.com</span>
+            <span class="service-tags"></span>
           </a>
         </div>
       </section>
@@ -57,6 +60,16 @@ describe('search filtering', () => {
     const cat2 = document.getElementById('cat2');
 
     searchInput.value = 'alpha';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    expect(alphaBtn.style.display).toBe('flex');
+    expect(betaBtn.style.display).toBe('none');
+    expect(gammaBtn.style.display).toBe('none');
+    expect(cat1.style.display).toBe('');
+    expect(cat2.style.display).toBe('none');
+
+    // search by tag
+    searchInput.value = 'news';
     searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
 
     expect(alphaBtn.style.display).toBe('flex');


### PR DESCRIPTION
## Summary
- allow `services.json` entries to include a `tags` array
- show service tags only when provided and include them in search
- test searching by tag
- document optional `tags` field

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445400aaa0832183c60a2c4b58eaf6