### PR TITLE
Add keyboard toggling for favorites

### DIFF
--- a/script.js
+++ b/script.js
@@ -228,6 +228,14 @@ function createServiceButton(service, favoritesSet, categoryName) {
     } else {
         star.textContent = '☆';
     }
+    star.tabIndex = 0;
+    star.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleFavorite(service.url);
+        }
+    });
     star.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/tests/favorites.test.js
+++ b/tests/favorites.test.js
@@ -45,4 +45,22 @@ describe('favorites management', () => {
     favSection = document.querySelector('#favorites');
     expect(favSection).toBeNull();
   });
+
+  test('toggling favorites via keyboard events', () => {
+    const star = document.querySelector('.favorite-star');
+
+    star.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(window.localStorage.getItem('favorites')).toBe(JSON.stringify(['http://alpha.com']));
+    let favSection = document.querySelector('#favorites');
+    expect(favSection).not.toBeNull();
+    expect(star.textContent).toBe('★');
+
+    star.dispatchEvent(new window.KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+    expect(window.localStorage.getItem('favorites')).toBe(JSON.stringify([]));
+    favSection = document.querySelector('#favorites');
+    expect(favSection).toBeNull();
+    expect(star.textContent).toBe('☆');
+  });
 });


### PR DESCRIPTION
## Summary
- make favorite star focusable and handle `keydown`
- test that keyboard events toggle favorites

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445a250648832191d9a74305d5c90b