### PR TITLE
Improve favorite star accessibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -222,16 +222,27 @@ function createServiceButton(service, favoritesSet, categoryName) {
 
     const star = document.createElement('span');
     star.className = 'favorite-star';
+    star.tabIndex = 0;
+    star.setAttribute('role', 'button');
     if (favoritesSet.has(service.url)) {
         star.textContent = '★';
         star.classList.add('favorited');
+        star.setAttribute('aria-label', 'Remove from favorites');
     } else {
         star.textContent = '☆';
+        star.setAttribute('aria-label', 'Add to favorites');
     }
     star.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         toggleFavorite(service.url);
+    });
+    star.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleFavorite(service.url);
+        }
     });
 
     serviceButton.appendChild(favicon);
@@ -263,9 +274,11 @@ function updateStars() {
         if (favorites.has(url)) {
             star.textContent = '★';
             star.classList.add('favorited');
+            star.setAttribute('aria-label', 'Remove from favorites');
         } else {
             star.textContent = '☆';
             star.classList.remove('favorited');
+            star.setAttribute('aria-label', 'Add to favorites');
         }
     });
     renderFavoritesCategory();

--- a/styles.css
+++ b/styles.css
@@ -169,6 +169,10 @@ main {
     font-size: 1.2rem;
     color: #ccc;
 }
+.favorite-star:focus {
+    outline: 2px solid #66b266;
+    outline-offset: 2px;
+}
 
 .favorite-star.favorited {
     color: gold;


### PR DESCRIPTION
## Summary
- make star element keyboard accessible with ARIA, tabIndex, and keydown handler
- update star label dynamically when favorites change
- style favorite star focus outline for visibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445a200c988321b325215d8709866a