### PR TITLE
Add error handling tests

### DIFF
--- a/tests/loadServicesError.test.js
+++ b/tests/loadServicesError.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('loadServices error handling', () => {
+  let window, document, dom;
+
+  beforeEach(() => {
+    const html = '<main></main>';
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('displays error message when fetch rejects', async () => {
+    window.fetch = jest.fn(() => Promise.reject(new Error('Network failed')));
+
+    await window.loadServices();
+
+    const main = document.querySelector('main');
+    expect(main.textContent).toContain('Failed to load services');
+  });
+
+  test('displays error message when response is not ok', async () => {
+    window.fetch = jest.fn(() => Promise.resolve({ ok: false, status: 500 }));
+
+    await window.loadServices();
+
+    const main = document.querySelector('main');
+    expect(main.textContent).toContain('Failed to load services');
+  });
+});


### PR DESCRIPTION
## Summary
- cover `loadServices` error paths with new tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445f11c8a88321b5198ff8728e2e62