### PR TITLE
Fix duplicate keydown handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -245,13 +245,6 @@ function createServiceButton(service, favoritesSet, categoryName) {
         e.stopPropagation();
         toggleFavorite(service.url);
     });
-    star.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleFavorite(service.url);
-        }
-    });
 
     serviceButton.appendChild(favicon);
     serviceButton.appendChild(serviceNameSpan);


### PR DESCRIPTION
## Summary
- remove redundant `keydown` listener in `createServiceButton`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445fac67f08321b79f287293227f3b