### PR TITLE
Fix DOMContentLoaded loadServices guard

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,8 +18,10 @@ document.addEventListener('DOMContentLoaded', () => {
         typeEffect();
     }
 
-    // Load services and set up functionalities
-    loadServices();
+    // Load services and set up functionalities only if a <main> element exists
+    if (document.querySelector('main')) {
+        loadServices();
+    }
 });
 
 async function loadServices() {


### PR DESCRIPTION
## Summary
- avoid calling `loadServices` automatically when `<main>` is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684469e888d08321b9e85d048017f02b