### PR TITLE
Add progressive web app support

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload entire repository including PWA files
+          path: './'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,9 @@ jspm_packages/
 
 # Gatsby files
 .cache/
-public
+public/
+!public/
+!public/manifest.json
 
 # VuePress build output
 .vuepress/dist

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ For most of these services, you typically need to:
 3.  Configure the build settings (usually minimal or none for a plain static site).
 4.  Deploy.
 
+## Installing the Dashboard as a PWA
+
+You can install the AI Services Dashboard on your device for quick access:
+
+1. Open the site in a modern browser such as Chrome or Edge.
+2. Click the install icon in the address bar or choose **Install App** from the browser menu.
+3. Confirm the prompt to add it to your home screen or applications list.
+
+After installation the dashboard can be launched like a native application and works offline thanks to the service worker.
+
 ## Contributing
 
 Contributions are welcome to enhance the AI Services Dashboard! If you have suggestions, bug reports, or want to add new services or features, please follow these steps:

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <meta name="twitter:description" content="Curated dashboard of AI services" />
     <meta name="twitter:image" content="./favicon.ico" />
     <title>AI Services Dashboard</title>
+    <link rel="manifest" href="public/manifest.json" />
     <link rel="stylesheet" href="./styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&amp;display=swap" />
     <link rel="icon" type="image/x-icon" href="./favicon.ico" />
@@ -31,5 +32,10 @@
         <p>© 2025 <a href="https://www.github.com/NathanNeurotic/" target="_blank" rel="noopener noreferrer">NathanNeurotic</a>. All rights reserved.</p>
     </footer>
     <script src="./script.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/service-worker.js');
+        }
+    </script>
 </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "AI Services Dashboard",
+  "short_name": "AI Dashboard",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "theme_color": "#1a1a1a",
+  "background_color": "#1a1a1a",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "32x32 64x64 128x128 256x256 512x512",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,32 @@
+const CACHE_NAME = 'ai-dashboard-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/script.js',
+  '/services.json',
+  '/favicon.ico',
+  '/public/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add PWA manifest file
- implement service worker caching the site files
- register the service worker from `index.html`
- include manifest and service worker in deployment
- document how to install the dashboard as a PWA
- adjust `.gitignore` so the manifest is tracked

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446e34f8788321b4ab07a30e806f40