### PR TITLE
Fix service worker registration path

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <script src="./script.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/service-worker.js');
+            navigator.serviceWorker.register('service-worker.js');
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- register the service worker without assuming a root path

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684477dd82dc8321a6fd1865b47b5fcf