### PR TITLE
Fix accordion dynamic height

### DIFF
--- a/script.js
+++ b/script.js
@@ -113,6 +113,7 @@ async function loadServices() {
             const isOpen = localStorage.getItem(`category-${id}`) === 'open';
             if (isOpen) {
                 content.classList.add('open');
+                content.style.maxHeight = content.scrollHeight + 'px';
                 chevron.classList.add('open');
                 header.setAttribute('aria-expanded', 'true');
             }
@@ -175,12 +176,14 @@ function toggleCategory(header) {
     const categoryId = header.parentElement.id;
 
     if (isOpen) {
+        content.style.maxHeight = '0px';
         content.classList.remove('open');
         chevron.classList.remove('open');
         header.setAttribute('aria-expanded', 'false');
         localStorage.setItem(`category-${categoryId}`, 'closed');
     } else {
         content.classList.add('open');
+        content.style.maxHeight = content.scrollHeight + 'px';
         chevron.classList.add('open');
         header.setAttribute('aria-expanded', 'true');
         localStorage.setItem(`category-${categoryId}`, 'open');

--- a/styles.css
+++ b/styles.css
@@ -162,7 +162,6 @@ main {
 }
 
 .category-content.open {
-    max-height: 3000px;
     opacity: 1;
     visibility: visible;
 }


### PR DESCRIPTION
## Summary
- use scrollHeight when opening/closing categories
- keep overflow hidden and remove fixed `max-height` from open class
- preserve expanded sections on load with correct heights

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684477d98cd08321abbb0b1ce190a1b5