### PR TITLE
Add scrollbar theming

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,8 @@
     --thanks-color: #4d8c4d;
     --font-family: 'VT323', monospace;
     --category-max-height: 400px;
+    --scroll-track: #0a0a0a;
+    --scroll-thumb: #5faa6f;
 }
 
 body {
@@ -35,6 +37,22 @@ body.light-mode {
     --footer-gradient: linear-gradient(180deg, #e0ecff 0%, #ffffff 100%);
     --thanks-color: #007acc;
     --font-family: 'Roboto', sans-serif;
+    --scroll-track: #f0f0f0;
+    --scroll-thumb: #a8d5a8;
+}
+
+* {
+    scrollbar-color: var(--scroll-thumb) var(--scroll-track);
+}
+::-webkit-scrollbar {
+    width: 8px;
+}
+::-webkit-scrollbar-track {
+    background: var(--scroll-track);
+}
+::-webkit-scrollbar-thumb {
+    background: var(--scroll-thumb);
+    border-radius: 4px;
 }
 
 header {


### PR DESCRIPTION
## Summary
- add `--scroll-track` and `--scroll-thumb` variables for dark and light themes
- apply global scrollbar styling so any scrollable area reflects the current theme

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447bccd2148321abb75deb8904a07e