### PR TITLE
Add Codex by OpenAI to services list

### DIFF
--- a/services.json
+++ b/services.json
@@ -569,6 +569,12 @@
         "category": "💻 Coding and Development"
     },
     {
+        "name": "Codex by OpenAI",
+        "url": "https://chatgpt.com/codex",
+        "favicon_url": "https://chatgpt.com/favicon.ico",
+        "category": "💻 Coding and Development"
+    },
+    {
         "name": "Codota",
         "url": "https://www.tabnine.com/",
         "favicon_url": "https://www.tabnine.com/favicon.ico",


### PR DESCRIPTION
## Summary
- include "Codex by OpenAI" in services.json under Coding and Development

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447df730748321ae5dccc81abbaded