### PR TITLE
Fix font width mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="manifest" href="public/manifest.json" />
     <link rel="stylesheet" href="./styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=VT323&amp;display=swap" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&amp;display=swap" />
     <link rel="icon" type="image/x-icon" href="./favicon.ico" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -37,7 +37,7 @@ body.light-mode {
     --button-gradient: linear-gradient(135deg, #ffffff 0%, #e6f3ff 100%);
     --footer-gradient: linear-gradient(180deg, #e0ecff 0%, #ffffff 100%);
     --thanks-color: #007acc;
-    --font-family: 'Roboto', sans-serif;
+    --font-family: 'Roboto Mono', monospace;
     --scroll-track: #f0f0f0;
     --scroll-thumb: #a8d5a8;
     --card-min-width: 300px;


### PR DESCRIPTION
## Summary
- use `Roboto Mono` font for light mode to match width of dark theme
- import `Roboto Mono` from Google Fonts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844823f69e0832181923e1336a0b1f0