### PR TITLE
Add optional thumbnail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The AI Services Dashboard is a static webpage designed to provide a curated list
 *   **Collapsible Sections:** Easily expand and collapse categories to manage visibility.
 *   **Direct Links:** Each service entry links directly to the respective service's website.
 *   **Favicon Display:** Shows favicons for listed services for quick visual identification.
+*   **Optional Thumbnails:** When provided, a small preview image is displayed above the service name.
 *   **Responsive Design:** Optimized for various screen sizes, including mobile devices.
     *   Header text wraps correctly on narrow screens.
     *   Interactive elements are properly handled in collapsed sections on mobile.
@@ -92,14 +93,15 @@ The AI Services Dashboard is built with standard HTML, CSS, and JavaScript. Here
 Service data is stored in `services.json`. To add a new service or update an existing one:
 
 1.  Open `services.json` in a text editor.
-2.  Add or edit an object in the JSON array with the fields `name`, `url`, `favicon_url`, and `category`. You can also optionally include a `tags` array for improved search results.
+2.  Add or edit an object in the JSON array with the fields `name`, `url`, `favicon_url`, and `category`. Optionally include `tags` for improved search results and a `thumbnail_url` to display a preview image.
     ```json
     {
         "name": "Example Service",
         "url": "https://example.com/",
         "favicon_url": "https://example.com/favicon.ico",
         "category": "My Category",
-        "tags": ["example", "demo"]
+        "tags": ["example", "demo"],
+        "thumbnail_url": "https://example.com/thumb.png"
     }
     ```
     Ensure the new entry follows the same format as shown above.

--- a/script.js
+++ b/script.js
@@ -207,6 +207,15 @@ function createServiceButton(service, favoritesSet, categoryName) {
     favicon.src = service.favicon_url || './favicon.ico';
     favicon.onerror = () => { favicon.src = './favicon.ico'; };
 
+    let thumbnail;
+    if (service.thumbnail_url) {
+        thumbnail = document.createElement('img');
+        thumbnail.className = 'service-thumbnail';
+        thumbnail.alt = `${service.name} thumbnail`;
+        thumbnail.src = service.thumbnail_url;
+        thumbnail.onerror = () => { thumbnail.style.display = 'none'; };
+    }
+
     const serviceNameSpan = document.createElement('span');
     serviceNameSpan.className = 'service-name';
     serviceNameSpan.textContent = service.name;
@@ -258,6 +267,9 @@ function createServiceButton(service, favoritesSet, categoryName) {
     });
 
     serviceButton.appendChild(favicon);
+    if (thumbnail) {
+        serviceButton.appendChild(thumbnail);
+    }
     serviceButton.appendChild(serviceNameSpan);
     serviceButton.appendChild(serviceUrlSpan);
     serviceButton.appendChild(serviceTagsSpan);

--- a/services.json
+++ b/services.json
@@ -4,7 +4,8 @@
         "url": "https://www.3daistudio.com/",
         "favicon_url": "https://www.3daistudio.com/favicon.ico",
         "category": "🔮 3D Modeling",
-        "tags": ["modeling", "design"]
+        "tags": ["modeling", "design"],
+        "thumbnail_url": "https://example.com/thumbs/3d-ai-studio.png"
     },
     {
         "name": "3DAIMaker",
@@ -609,6 +610,7 @@
         "url": "https://codeassist.google.com/",
         "favicon_url": "https://codeassist.google.com/favicon.ico",
         "category": "💻 Coding and Development"
+        "thumbnail_url": "https://example.com/thumbs/google-code-assist.png",
     },
     {
         "name": "Jules",
@@ -951,6 +953,7 @@
         "url": "https://codeassist.google.com/",
         "favicon_url": "https://codeassist.google.com/favicon.ico",
         "category": "✨ Google Ecosystem"
+        "thumbnail_url": "https://example.com/thumbs/google-code-assist.png"
     },
     {
         "name": "Google DeepMind",
@@ -1649,6 +1652,7 @@
         "url": "https://www.jasper.ai/",
         "favicon_url": "https://www.jasper.ai/favicon.ico",
         "category": "📚 Articles and Reviews"
+        "thumbnail_url": "https://example.com/thumbs/jasper.png"
     },
     {
         "name": "Sudowrite",

--- a/styles.css
+++ b/styles.css
@@ -231,6 +231,14 @@ main {
     vertical-align: middle;
 }
 
+.service-thumbnail {
+    width: 100%;
+    max-height: 150px;
+    object-fit: cover;
+    margin-bottom: 0.5rem;
+    border-radius: 8px;
+}
+
 .favorite-star {
     position: absolute;
     top: 8px;

--- a/tests/loadServices.test.js
+++ b/tests/loadServices.test.js
@@ -63,8 +63,12 @@ describe('loadServices', () => {
   });
 
   test('service button includes thumbnail image when provided', () => {
-    const firstButton = document.querySelector('.service-button');
-    const thumb = firstButton.querySelector('img.service-thumbnail');
+    const buttons = Array.from(document.querySelectorAll('.service-button'));
+    const target = buttons.find(btn =>
+      btn.querySelector('.service-name').textContent === 'One'
+    );
+    expect(target).toBeDefined();
+    const thumb = target.querySelector('img.service-thumbnail');
     expect(thumb).not.toBeNull();
     expect(thumb.getAttribute('src')).toBe('thumb-one.png');
   });

--- a/tests/loadServices.test.js
+++ b/tests/loadServices.test.js
@@ -17,7 +17,13 @@ describe('loadServices', () => {
     document.body.appendChild(scriptEl);
 
     const servicesData = [
-      { name: 'One', url: 'http://one.com', favicon_url: 'one.ico', category: 'Banana' },
+      {
+        name: 'One',
+        url: 'http://one.com',
+        favicon_url: 'one.ico',
+        category: 'Banana',
+        thumbnail_url: 'thumb-one.png'
+      },
       { name: 'Two', url: 'http://two.com', favicon_url: 'two.ico', category: 'Apple' }
     ];
 
@@ -54,5 +60,12 @@ describe('loadServices', () => {
     firstHeader.dispatchEvent(event);
 
     expect(content.classList.contains('open')).toBe(true);
+  });
+
+  test('service button includes thumbnail image when provided', () => {
+    const firstButton = document.querySelector('.service-button');
+    const thumb = firstButton.querySelector('img.service-thumbnail');
+    expect(thumb).not.toBeNull();
+    expect(thumb.getAttribute('src')).toBe('thumb-one.png');
   });
 });


### PR DESCRIPTION
## Summary
- allow services to specify a `thumbnail_url`
- show thumbnail images in service buttons
- style `.service-thumbnail` elements
- document thumbnail usage
- add example `thumbnail_url` entries in `services.json`
- test that service buttons render the thumbnail when provided

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448826d4248321af3457609a40ee75