### PR TITLE
Adjust favorites header styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -328,7 +328,10 @@ function renderFavoritesCategory() {
         favoritesSection.id = 'favorites';
 
         const header = document.createElement('h2');
-        header.innerHTML = '★ Favorites <span class="chevron">▼</span>';
+        header.innerHTML =
+            `<span class="category-emoji">⭐</span>
+             <span class="category-title">Favorites</span>
+             <span class="chevron">▼</span>`;
         header.setAttribute('aria-expanded', 'true');
         header.onclick = () => toggleCategory(header);
         header.tabIndex = 0;

--- a/styles.css
+++ b/styles.css
@@ -171,6 +171,15 @@ main {
     transform: rotate(180deg);
 }
 
+.category-title {
+    flex: 1;
+    text-align: center;
+}
+
+.category-emoji {
+    margin-right: 0.5rem;
+}
+
 .category-content {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr));


### PR DESCRIPTION
## Summary
- adjust Favorites header to use structured HTML with a star emoji
- add `.category-title` and `.category-emoji` styles for layout

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68448d67e4cc83219d994cb860cbd194