### PR TITLE
Add category block view toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <img id="header-favicon" src="./favicon.ico" alt="AI Services Dashboard Favicon" />
         <h1 class="typing-effect">AI Services Dashboard</h1>
         <button id="themeToggle" onclick="toggleTheme()" aria-label="Toggle theme">Toggle Theme</button>
+        <button id="viewToggle" onclick="toggleView()" aria-label="Toggle category view">Toggle View</button>
     </header>
     <main>
         <div class="search-container">

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const MAX_CATEGORY_HEIGHT = 400; // px - limit for open category height
 
 document.addEventListener('DOMContentLoaded', () => {
     applySavedTheme();
+    applySavedView();
     // Typing Effect for Header
     const headerTextElement = document.querySelector('.typing-effect');
     const textToType = 'AI Services Dashboard';
@@ -378,4 +379,18 @@ function toggleTheme() {
 }
 
 window.toggleTheme = toggleTheme;
+
+function applySavedView() {
+    const saved = localStorage.getItem('view');
+    if (saved === 'block') {
+        document.body.classList.add('block-view');
+    }
+}
+
+function toggleView() {
+    const isBlock = document.body.classList.toggle('block-view');
+    localStorage.setItem('view', isBlock ? 'block' : 'list');
+}
+
+window.toggleView = toggleView;
 

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,7 @@
     --scroll-track: #0a0a0a;
     --scroll-thumb: #5faa6f;
     --card-min-width: 300px;
+    --category-min-width: 300px;
 }
 
 body {
@@ -41,6 +42,7 @@ body.light-mode {
     --scroll-track: #f0f0f0;
     --scroll-thumb: #a8d5a8;
     --card-min-width: 300px;
+    --category-min-width: 300px;
 }
 
 html.light-mode {
@@ -82,6 +84,19 @@ header {
     margin-top: 1rem;
 }
 
+#viewToggle {
+    background: none;
+    border: 2px solid var(--text-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: 1rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 5px;
+    cursor: pointer;
+    margin-top: 1rem;
+    margin-left: 0.5rem;
+}
+
 #header-favicon {
     display: block;
     width: 50px;
@@ -113,6 +128,21 @@ main {
     margin: 2rem auto;
     padding: 0 1rem;
     flex: 1;
+}
+
+body.block-view main {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--category-min-width), 1fr));
+    gap: 1rem;
+}
+
+body.block-view main > .search-container,
+body.block-view main > #favorites {
+    grid-column: 1 / -1;
+}
+
+body.block-view .category {
+    margin-bottom: 0;
 }
 
 .search-container {

--- a/tests/viewToggle.test.js
+++ b/tests/viewToggle.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('toggleView', () => {
+  let window, document, dom;
+
+  beforeEach(() => {
+    dom = new JSDOM('<body></body>', { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('toggles block-view class and localStorage state', () => {
+    expect(document.body.classList.contains('block-view')).toBe(false);
+    expect(window.localStorage.getItem('view')).toBe(null);
+
+    window.toggleView();
+
+    expect(document.body.classList.contains('block-view')).toBe(true);
+    expect(window.localStorage.getItem('view')).toBe('block');
+
+    window.toggleView();
+
+    expect(document.body.classList.contains('block-view')).toBe(false);
+    expect(window.localStorage.getItem('view')).toBe('list');
+  });
+});


### PR DESCRIPTION
## Summary
- allow switching between list and block views
- persist block view preference in `localStorage`
- style layout for `block-view`
- test toggleView helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f6bb51bc8321939f5d19878118ed