### PR TITLE
Fix horizontal overflow with box-sizing

### DIFF
--- a/chatgpt.html
+++ b/chatgpt.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gemini 2.5 Pro vs GPT-4.5 Comparison</title>
     <style>
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
         body { font-family: Arial, sans-serif; background-color: #f4f7fc; color: #333; padding: 20px; }
         h1, h2 { color: #34495e; }
         table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }

--- a/gemini.html
+++ b/gemini.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Illuminating the AI Frontier: An Analysis of ChatGPT 4.5's Advantages Over Gemini 2.5 Pro</title>
     <style>
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
         body {
             font-family: sans-serif;
             line-height: 1.6;

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,7 @@ html.light-mode {
 
 * {
     scrollbar-color: var(--scroll-thumb) var(--scroll-track);
+    box-sizing: border-box;
 }
 ::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
## Summary
- apply border-box sizing globally to avoid layout overflow
- ensure stand-alone pages (chatgpt.html and gemini.html) also use border-box

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fc0b8db48321adbe6398be3c00b5