### PR TITLE
Fix category header alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,7 +84,7 @@ async function loadServices() {
                 textContent = categoryName.substring(emojiMatch[0].length).trim();
             }
 
-            categoryHeader.innerHTML = `${emojiSpan}${textContent} <span class="chevron">▼</span>`;
+            categoryHeader.innerHTML = `${emojiSpan}<span class="category-title">${textContent}</span> <span class="chevron">▼</span>`;
 
 
             const categoryContent = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure dynamic category headers wrap text in `.category-title` so they stay centered

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450150543883219870fa4d40f1e877