### PR TITLE
Fix favorites duplicates

### DIFF
--- a/script.js
+++ b/script.js
@@ -314,7 +314,14 @@ function renderFavoritesCategory() {
     let favoritesSection = document.getElementById('favorites');
     const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
     const favoritesSet = new Set(favorites);
-    const favoriteServices = allServices.filter(s => favoritesSet.has(s.url));
+    const favoriteServices = [];
+    const seen = new Set();
+    for (const service of allServices) {
+        if (favoritesSet.has(service.url) && !seen.has(service.url)) {
+            favoriteServices.push(service);
+            seen.add(service.url);
+        }
+    }
 
     if (favoriteServices.length === 0) {
         if (favoritesSection) {

--- a/tests/favoritesDedup.test.js
+++ b/tests/favoritesDedup.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('favorites deduplication', () => {
+  let window, document, dom;
+
+  beforeEach(async () => {
+    const html = '<main></main>';
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const sampleServices = [
+      { name: 'Alpha', url: 'http://alpha.com', favicon_url: 'alpha.ico', category: 'Test' },
+      { name: 'Alpha Duplicate', url: 'http://alpha.com', favicon_url: 'alpha.ico', category: 'Other' }
+    ];
+
+    window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(sampleServices) }));
+
+    await window.loadServices();
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('only one favorite entry is shown when service appears multiple times', () => {
+    const star = document.querySelector('.favorite-star');
+    star.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    const favButtons = document.querySelectorAll('#favorites .service-button');
+    expect(favButtons.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure favorite services only appear once by deduplicating by URL
- add regression test for duplicate favorites

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684504b2a35083219fbb2df37df954a8