### PR TITLE
Add category list view option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The AI Services Dashboard is a static webpage designed to provide a curated list
 *   **Themed Interface:** Retro-terminal aesthetic with a typing effect in the header.
 *   **Alphabetical Sorting:** Categories and services are automatically sorted alphabetically when `script.js` dynamically loads `services.json`.
 *   **Favorites:** Mark services with the star icon to quickly access them in a dedicated "Favorites" category that persists using `localStorage`.
+*   **Category View Toggle:** Each category can switch between grid and list layouts independently, and the choice is remembered.
 
 ## Getting Started
 

--- a/script.js
+++ b/script.js
@@ -84,7 +84,19 @@ async function loadServices() {
                 textContent = categoryName.substring(emojiMatch[0].length).trim();
             }
 
-            categoryHeader.innerHTML = `${emojiSpan}<span class="category-title">${textContent}</span> <span class="chevron">▼</span>`;
+            categoryHeader.innerHTML = `${emojiSpan}<span class="category-title">${textContent}</span> <span class="chevron">▼</span><span class="category-view-toggle" role="button" tabindex="0" aria-label="Toggle category view">☰</span>`;
+            const viewToggle = categoryHeader.querySelector('.category-view-toggle');
+            viewToggle.addEventListener('click', (e) => {
+                e.stopPropagation();
+                toggleCategoryView(categoryId);
+            });
+            viewToggle.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    toggleCategoryView(categoryId);
+                }
+            });
 
 
             const categoryContent = document.createElement('div');
@@ -119,6 +131,11 @@ async function loadServices() {
                 content.style.maxHeight = height + 'px';
                 chevron.classList.add('open');
                 header.setAttribute('aria-expanded', 'true');
+            }
+
+            const view = localStorage.getItem(`view-${id}`);
+            if (view === 'list') {
+                category.classList.add('list-view');
             }
         });
 
@@ -400,4 +417,13 @@ function toggleView() {
 }
 
 window.toggleView = toggleView;
+
+function toggleCategoryView(categoryId) {
+    const section = document.getElementById(categoryId);
+    if (!section) return;
+    const isList = section.classList.toggle('list-view');
+    localStorage.setItem(`view-${categoryId}`, isList ? 'list' : 'grid');
+}
+
+window.toggleCategoryView = toggleCategoryView;
 

--- a/styles.css
+++ b/styles.css
@@ -202,6 +202,15 @@ body.block-view .category {
     transform: rotate(180deg);
 }
 
+.category-view-toggle {
+    margin-left: 0.5rem;
+    cursor: pointer;
+}
+.category-view-toggle:focus {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+}
+
 .category-title {
     flex: 1;
     text-align: center;
@@ -236,6 +245,20 @@ body.block-view .category {
     max-height: var(--category-max-height);
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+.category.list-view .category-content {
+    display: flex;
+    flex-direction: column;
+}
+
+.category.list-view .service-button {
+    flex-direction: row;
+    align-items: center;
+}
+.category.list-view .service-name {
+    margin-bottom: 0;
+    margin-right: 0.5rem;
 }
 
 .service-button {
@@ -310,6 +333,10 @@ body.block-view .category {
 .service-url {
     font-size: 1rem;
     word-break: break-all;
+}
+
+.category.list-view .service-url {
+    margin-left: auto;
 }
 
 .service-tags {

--- a/tests/categoryViewToggle.test.js
+++ b/tests/categoryViewToggle.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('toggleCategoryView', () => {
+  let window, document, dom;
+
+  beforeEach(() => {
+    const html = `
+      <section class="category" id="test">
+        <h2 aria-expanded="false">Title <span class="chevron">▼</span><span class="category-view-toggle"></span></h2>
+        <div class="category-content"></div>
+      </section>
+    `;
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('toggles list-view class and localStorage state', () => {
+    const section = document.getElementById('test');
+
+    expect(section.classList.contains('list-view')).toBe(false);
+    expect(window.localStorage.getItem('view-test')).toBe(null);
+
+    window.toggleCategoryView('test');
+
+    expect(section.classList.contains('list-view')).toBe(true);
+    expect(window.localStorage.getItem('view-test')).toBe('list');
+
+    window.toggleCategoryView('test');
+
+    expect(section.classList.contains('list-view')).toBe(false);
+    expect(window.localStorage.getItem('view-test')).toBe('grid');
+  });
+});


### PR DESCRIPTION
## Summary
- allow toggling a list view per category
- persist list view state in `localStorage`
- style list view layout and new toggle icon
- test the new `toggleCategoryView` function
- document category view toggle feature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450793778083218aed962dccecc376