### PR TITLE
Add list view toggle for favorites

### DIFF
--- a/script.js
+++ b/script.js
@@ -361,7 +361,8 @@ function renderFavoritesCategory() {
         header.innerHTML =
             `<span class="category-emoji">⭐</span>
              <span class="category-title">Favorites</span>
-             <span class="chevron">▼</span>`;
+             <span class="chevron">▼</span>
+             <span class="category-view-toggle" role="button" tabindex="0" aria-label="Toggle category view">☰</span>`;
         header.setAttribute('aria-expanded', 'true');
         header.onclick = () => toggleCategory(header);
         header.tabIndex = 0;
@@ -369,6 +370,19 @@ function renderFavoritesCategory() {
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 toggleCategory(header);
+            }
+        });
+
+        const viewToggle = header.querySelector('.category-view-toggle');
+        viewToggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            toggleCategoryView('favorites');
+        });
+        viewToggle.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleCategoryView('favorites');
             }
         });
 
@@ -391,6 +405,21 @@ function renderFavoritesCategory() {
         const btn = createServiceButton(service, favoritesSet);
         content.appendChild(btn);
     });
+
+    const view = localStorage.getItem('view-favorites');
+    if (view === 'list') {
+        favoritesSection.classList.add('list-view');
+        const toggle = favoritesSection.querySelector('.category-view-toggle');
+        if (toggle) {
+            toggle.classList.add('active');
+        }
+    } else {
+        favoritesSection.classList.remove('list-view');
+        const toggle = favoritesSection.querySelector('.category-view-toggle');
+        if (toggle) {
+            toggle.classList.remove('active');
+        }
+    }
 }
 
 function applySavedTheme() {

--- a/tests/favoritesViewToggle.test.js
+++ b/tests/favoritesViewToggle.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('favorites category view toggle', () => {
+  let window, document, dom;
+
+  beforeEach(async () => {
+    const html = '<main></main>';
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const sampleServices = [
+      { name: 'Alpha', url: 'http://alpha.com', favicon_url: 'alpha.ico', category: 'Test' }
+    ];
+
+    window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(sampleServices) }));
+
+    await window.loadServices();
+
+    const star = document.querySelector('.favorite-star');
+    star.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('toggleCategoryView toggles list view for favorites', () => {
+    const favSection = document.getElementById('favorites');
+    const toggle = favSection.querySelector('.category-view-toggle');
+
+    expect(toggle).not.toBeNull();
+    expect(favSection.classList.contains('list-view')).toBe(false);
+    expect(window.localStorage.getItem('view-favorites')).toBe(null);
+
+    window.toggleCategoryView('favorites');
+
+    expect(favSection.classList.contains('list-view')).toBe(true);
+    expect(window.localStorage.getItem('view-favorites')).toBe('list');
+    expect(toggle.classList.contains('active')).toBe(true);
+
+    window.toggleCategoryView('favorites');
+
+    expect(favSection.classList.contains('list-view')).toBe(false);
+    expect(window.localStorage.getItem('view-favorites')).toBe('grid');
+    expect(toggle.classList.contains('active')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- enable list view toggle for the Favorites category like other categories
- remember the Favorites view state and reflect active status
- test Favorites category view toggle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450c1401d48321bab22f4cd06fa5fb