### PR TITLE
Fix manifest start_url and scope

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "AI Services Dashboard",
   "short_name": "AI Dashboard",
-  "start_url": "/index.html",
+  "start_url": "./index.html",
+  "scope": "./",
   "display": "standalone",
   "theme_color": "#1a1a1a",
   "background_color": "#1a1a1a",


### PR DESCRIPTION
## Summary
- fix `public/manifest.json` start_url so PWA uses a relative path
- set manifest scope to `./`

## Testing
- `npm test` *(fails: jest missing)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684538ecd2e08321b27a4aca87df6fe4