### PR TITLE
Fix: make cached URLs relative for subpath deployments

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'ai-dashboard-cache-v1';
 const URLS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/script.js',
-  '/services.json',
-  '/favicon.ico',
-  '/public/manifest.json'
+  './',
+  './index.html',
+  './styles.css',
+  './script.js',
+  './services.json',
+  './favicon.ico',
+  './public/manifest.json'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- make service worker cache relative URLs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845395adc408321a9d5f63cd8b341da