### PR TITLE
Fix manifest icon path

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,7 @@
   "background_color": "#1a1a1a",
   "icons": [
     {
-      "src": "/favicon.ico",
+      "src": "./favicon.ico",
       "sizes": "32x32 64x64 128x128 256x256 512x512",
       "type": "image/x-icon"
     }


### PR DESCRIPTION
## Summary
- fix icon path in `public/manifest.json` so PWA install works correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453ae91ca083218a8a4383361658a5