### PR TITLE
Add: PWA support on extra pages

### DIFF
--- a/chatgpt.html
+++ b/chatgpt.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gemini 2.5 Pro vs GPT-4.5 Comparison</title>
+    <link rel="manifest" href="public/manifest.json">
     <style>
         *, *::before, *::after {
             box-sizing: border-box;
@@ -137,5 +138,10 @@
     <p>Gemini 2.5 Pro surpasses GPT-4.5 strictly on technical AI features at the $20/month price point, offering significant advantages in context handling, multimodal integration, memory persistence, and complex task management, though GPT-4.5 maintains strengths in speed, nuanced interactions, and plugin integrations.</p>
 </div>
 
+<script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+</script>
 </body>
 </html>

--- a/gemini.html
+++ b/gemini.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Illuminating the AI Frontier: An Analysis of ChatGPT 4.5's Advantages Over Gemini 2.5 Pro</title>
+    <link rel="manifest" href="public/manifest.json">
     <style>
         *, *::before, *::after {
             box-sizing: border-box;
@@ -352,5 +353,11 @@
         <h3>D. Final Word on the Competitive Landscape</h3>
         <p>It is clear that both ChatGPT 4.5 and Gemini 2.5 Pro are formidable AI models, each pushing the boundaries of what is currently achievable. However, for the specific AI features and advantages detailed throughout this report—ranging from conversational depth and factual precision to creative expression and tool-assisted reasoning—ChatGPT 4.5 presents a compelling and often superior case. Its unique combination of intuitive understanding, broad knowledge, and practical problem-solving capabilities positions it as a leading choice for a wide array of demanding AI-driven objectives.</p>
     </div>
+
+<script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `chatgpt.html` and `gemini.html` with manifest link tags
- register the service worker on both pages for PWA support

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453bf335248321af04e8a8b9a80796