### PR TITLE
Fix service worker cache list

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,5 @@
 const CACHE_NAME = 'ai-dashboard-cache-v1';
 const URLS_TO_CACHE = [
-  './',
   './index.html',
   './styles.css',
   './script.js',


### PR DESCRIPTION
## Summary
- remove `./` from the list of URLs to cache

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453c70c43083218611b07d38a41677