### PR TITLE
Fix: Improve PWA icon handling and add Apple touch icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="./styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&amp;display=swap" />
     <link rel="icon" type="image/x-icon" href="./favicon.ico" />
+    <link rel="apple-touch-icon" href="./favicon.ico">
 </head>
 <body>
     <header>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,9 +8,14 @@
   "background_color": "#1a1a1a",
   "icons": [
     {
-      "src": "./favicon.ico",
-      "sizes": "32x32 64x64 128x128 256x256 512x512",
-      "type": "image/x-icon"
+      "src": "public/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "public/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ]
 }


### PR DESCRIPTION
This commit introduces the following changes:

1.  Adds an `apple-touch-icon` link to `index.html` pointing to `favicon.ico`. This will allow users on iOS devices to have a proper icon when they add your website to their home screen.
2.  Updates the `public/manifest.json` to reference dedicated PNG icons (192x192 and 512x512) instead of the multi-size `favicon.ico`. This aligns with best practices for PWAs, ensuring better icon quality on various platforms (Android, Desktop). Note: The actual PNG image files (e.g., `public/icon-192x192.png`, `public/icon-512x512.png`) need to be created and added to the repository for the manifest changes to be fully effective.
3.  Verified that existing links to `favicon.ico` in `index.html` for browser favicon, Open Graph, and Twitter cards are correctly specified.

These changes enhance the 'install as app' experience and ensure better icon representation across different devices and platforms.