### PR TITLE
Add sidebar navigation with collapsible menu

### DIFF
--- a/chatgpt.html
+++ b/chatgpt.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gemini 2.5 Pro vs GPT-4.5 Comparison</title>
     <link rel="manifest" href="public/manifest.json">
+    <link rel="stylesheet" href="styles.css">
     <style>
         *, *::before, *::after {
             box-sizing: border-box;
@@ -21,6 +22,8 @@
     </style>
 </head>
 <body>
+    <nav id="sidebar"></nav>
+    <button id="sidebarToggle" aria-label="Toggle sidebar">☰</button>
 
 <h1>Gemini 2.5 Pro vs GPT-4.5 (ChatGPT)</h1>
 
@@ -143,5 +146,6 @@
       navigator.serviceWorker.register('service-worker.js');
     }
 </script>
+<script src="./script.js"></script>
 </body>
 </html>

--- a/gemini.html
+++ b/gemini.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Illuminating the AI Frontier: An Analysis of ChatGPT 4.5's Advantages Over Gemini 2.5 Pro</title>
     <link rel="manifest" href="public/manifest.json">
+    <link rel="stylesheet" href="styles.css">
     <style>
         *, *::before, *::after {
             box-sizing: border-box;
@@ -64,6 +65,8 @@
     </style>
 </head>
 <body>
+    <nav id="sidebar"></nav>
+    <button id="sidebarToggle" aria-label="Toggle sidebar">☰</button>
     <div class="container">
         <h1>Illuminating the AI Frontier: An Analysis of ChatGPT 4.5's Advantages Over Gemini 2.5 Pro</h1>
 
@@ -359,5 +362,6 @@
       navigator.serviceWorker.register('service-worker.js');
     }
 </script>
+<script src="./script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,11 @@
     <link rel="apple-touch-icon" href="./public/icon-192x192.png">
 </head>
 <body>
+    <nav id="sidebar"></nav>
     <header>
         <img id="header-favicon" src="./favicon.ico" alt="AI Services Dashboard Favicon" />
         <h1 class="typing-effect">AI Services Dashboard</h1>
+        <button id="sidebarToggle" aria-label="Toggle sidebar">☰</button>
         <button id="themeToggle" onclick="toggleTheme()" aria-label="Toggle theme">Toggle Theme</button>
         <button id="viewToggle" onclick="toggleView()" aria-label="Toggle category view">Toggle View</button>
         <button id="installBtn" aria-label="Install app">Install App</button>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,13 @@ document.addEventListener('DOMContentLoaded', () => {
     applySavedView();
     updateToggleButtons();
 
+    buildSidebar();
+
+    const sidebarToggle = document.getElementById('sidebarToggle');
+    if (sidebarToggle) {
+        sidebarToggle.addEventListener('click', toggleSidebar);
+    }
+
     const installBtn = document.getElementById('installBtn');
     if (installBtn) {
         installBtn.style.display = 'none';
@@ -171,6 +178,8 @@ async function loadServices() {
                 }
             }
         });
+
+        buildSidebar();
 
         // Re-initialize search functionality
         setupSearch();
@@ -505,4 +514,31 @@ function updateToggleButtons() {
         viewBtn.classList.toggle('active', document.body.classList.contains('block-view'));
     }
 }
+
+function buildSidebar() {
+    const sidebar = document.getElementById('sidebar');
+    if (!sidebar) return;
+    sidebar.innerHTML = '';
+    const sections = document.querySelectorAll('.category');
+    sections.forEach(section => {
+        const titleEl = section.querySelector('.category-title');
+        if (!titleEl) return;
+        const link = document.createElement('a');
+        link.href = `#${section.id}`;
+        link.textContent = titleEl.textContent;
+        link.addEventListener('click', () => {
+            toggleSidebar();
+        });
+        sidebar.appendChild(link);
+    });
+}
+
+function toggleSidebar() {
+    const sidebar = document.getElementById('sidebar');
+    if (!sidebar) return;
+    sidebar.classList.toggle('open');
+}
+
+window.toggleSidebar = toggleSidebar;
+window.buildSidebar = buildSidebar;
 

--- a/styles.css
+++ b/styles.css
@@ -117,6 +117,47 @@ header {
     display: none;
 }
 
+#sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 200px;
+    height: 100%;
+    background: var(--content-bg);
+    backdrop-filter: blur(3px);
+    border-right: 2px solid var(--text-color);
+    padding: 1rem;
+    box-sizing: border-box;
+    overflow-y: auto;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+}
+
+#sidebar.open {
+    transform: translateX(0);
+}
+
+#sidebar a {
+    display: block;
+    color: var(--text-color);
+    text-decoration: none;
+    margin-bottom: 0.5rem;
+}
+
+#sidebarToggle {
+    background: none;
+    border: 2px solid var(--text-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: 1rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 5px;
+    cursor: pointer;
+    margin-top: 1rem;
+    margin-right: 0.5rem;
+}
+
 #header-favicon {
     display: block;
     width: 50px;

--- a/tests/sidebar.test.js
+++ b/tests/sidebar.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('sidebar navigation', () => {
+  let window, document, dom;
+
+  beforeEach(async () => {
+    const html = `<nav id="sidebar"></nav><button id="sidebarToggle"></button><main></main>`;
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const services = [
+      { name: 'One', url: 'http://one.com', category: 'Alpha' },
+      { name: 'Two', url: 'http://two.com', category: 'Beta' }
+    ];
+
+    window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(services) }));
+
+    await window.loadServices();
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('buildSidebar lists categories', () => {
+    const links = document.querySelectorAll('#sidebar a');
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute('href')).toBe('#alpha');
+    expect(links[0].textContent).toBe('Alpha');
+  });
+
+  test('toggleSidebar toggles open class', () => {
+    const sidebar = document.getElementById('sidebar');
+    expect(sidebar.classList.contains('open')).toBe(false);
+    window.toggleSidebar();
+    expect(sidebar.classList.contains('open')).toBe(true);
+    window.toggleSidebar();
+    expect(sidebar.classList.contains('open')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add collapsible sidebar in index and article pages
- style sidebar and toggle button
- generate sidebar links from headings via script.js
- expose `toggleSidebar` and `buildSidebar` functions
- include new Jest test for sidebar functionality

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b5a6a43883219fbeaf322400cd0c