### PR TITLE
Enhance sidebar visuals and add repo links

### DIFF
--- a/chatgpt.html
+++ b/chatgpt.html
@@ -147,5 +147,8 @@
     }
 </script>
 <script src="./script.js"></script>
+<footer>
+    <p><a href="https://www.github.com/NathanNeurotic/AI" target="_blank" rel="noopener noreferrer">GitHub Repository</a></p>
+</footer>
 </body>
 </html>

--- a/gemini.html
+++ b/gemini.html
@@ -363,5 +363,8 @@
     }
 </script>
 <script src="./script.js"></script>
+<footer>
+    <p><a href="https://www.github.com/NathanNeurotic/AI" target="_blank" rel="noopener noreferrer">GitHub Repository</a></p>
+</footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     </main>
     <footer>
         <p>© 2025 <a href="https://www.github.com/NathanNeurotic/" target="_blank" rel="noopener noreferrer">NathanNeurotic</a>. All rights reserved.</p>
+        <p><a href="https://www.github.com/NathanNeurotic/AI" target="_blank" rel="noopener noreferrer">GitHub Repository</a></p>
     </footer>
     <script src="./script.js"></script>
     <script>

--- a/script.js
+++ b/script.js
@@ -531,6 +531,12 @@ function buildSidebar() {
         });
         sidebar.appendChild(link);
     });
+    const repoLink = document.createElement('a');
+    repoLink.href = 'https://www.github.com/NathanNeurotic/AI';
+    repoLink.textContent = 'GitHub Repository';
+    repoLink.target = '_blank';
+    repoLink.rel = 'noopener noreferrer';
+    sidebar.appendChild(repoLink);
 }
 
 function toggleSidebar() {

--- a/styles.css
+++ b/styles.css
@@ -143,10 +143,23 @@ header {
     color: var(--text-color);
     text-decoration: none;
     margin-bottom: 0.5rem;
+    padding: 0.25rem 0 0.25rem 1rem;
+    border-bottom: 1px solid var(--text-color);
+    position: relative;
+}
+
+#sidebar a::before {
+    content: "\2022"; /* bullet */
+    position: absolute;
+    left: 0;
+}
+
+#sidebar a:last-child {
+    border-bottom: none;
 }
 
 #sidebarToggle {
-    background: none;
+    background: var(--button-gradient);
     border: 2px solid var(--text-color);
     color: var(--text-color);
     font-family: var(--font-family);

--- a/tests/sidebar.test.js
+++ b/tests/sidebar.test.js
@@ -30,11 +30,12 @@ describe('sidebar navigation', () => {
     window.close();
   });
 
-  test('buildSidebar lists categories', () => {
+  test('buildSidebar lists categories and repo link', () => {
     const links = document.querySelectorAll('#sidebar a');
-    expect(links.length).toBe(2);
+    expect(links.length).toBe(3);
     expect(links[0].getAttribute('href')).toBe('#alpha');
     expect(links[0].textContent).toBe('Alpha');
+    expect(links[2].getAttribute('href')).toBe('https://www.github.com/NathanNeurotic/AI');
   });
 
   test('toggleSidebar toggles open class', () => {


### PR DESCRIPTION
## Summary
- style sidebar links with bullets and separators
- make sidebar toggle button use a solid background
- include GitHub repository link in sidebar generation
- add repo footer links to all pages
- adjust sidebar test for new repo link

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bb7bf7fc83218df266a1ab07f237