### PR TITLE
Add user feedback for empty search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <div class="search-container">
             <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" />
         </div>
+        <p id="noResults" class="no-results" hidden>No results found.</p>
         <!-- Service listings will be dynamically injected here by script.js -->
     </main>
     <footer>

--- a/script.js
+++ b/script.js
@@ -211,6 +211,17 @@ function setupSearch() {
             button.style.display = (name.includes(query) || url.includes(query) || tagsMatch) ? 'flex' : 'none';
         });
 
+        const visibleButtons = Array.from(document.querySelectorAll('.service-button'))
+            .filter(btn => btn.style.display !== 'none').length;
+        const noResultsEl = document.getElementById('noResults');
+        if (noResultsEl) {
+            if (query !== '' && visibleButtons === 0) {
+                noResultsEl.hidden = false;
+            } else {
+                noResultsEl.hidden = true;
+            }
+        }
+
         // Optional: Hide categories if all services within them are hidden
         document.querySelectorAll('.category').forEach(category => {
             const services = category.querySelectorAll('.service-button');

--- a/styles.css
+++ b/styles.css
@@ -251,6 +251,13 @@ body.block-view .category {
     box-shadow: 0 0 8px rgba(102, 178, 102, 0.3);
 }
 
+.no-results {
+    color: var(--text-color);
+    text-align: center;
+    font-family: var(--font-family);
+    margin-top: 1rem;
+}
+
 .category {
     margin-bottom: 1.5rem;
 }

--- a/tests/searchNoResults.test.js
+++ b/tests/searchNoResults.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('search no results message', () => {
+  let window, document, searchInput, noResults;
+
+  beforeEach(() => {
+    const html = `
+      <div class="search-container">
+        <input id="searchInput" type="text" />
+      </div>
+      <p id="noResults" hidden>No results found.</p>
+      <section class="category" id="cat1">
+        <h2>Category 1</h2>
+        <div class="category-content">
+          <a class="service-button">
+            <span class="service-name">Alpha</span>
+            <span class="service-url">http://alpha.com</span>
+            <span class="service-tags">news</span>
+          </a>
+        </div>
+      </section>
+    `;
+    const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    window.setupSearch();
+    searchInput = document.getElementById('searchInput');
+    noResults = document.getElementById('noResults');
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('displays and hides no results message', () => {
+    searchInput.value = 'zzz';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(noResults.hidden).toBe(false);
+
+    searchInput.value = '';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(noResults.hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- show a "No results" paragraph beneath search bar
- style new no-results element
- toggle the message in `setupSearch`
- test that no-results message toggles correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c16a81dc832180d05f19c3942ac2