### PR TITLE
Fix favorites controls and responsive sidebar

### DIFF
--- a/script.js
+++ b/script.js
@@ -279,12 +279,6 @@ function createServiceButton(service, favoritesSet, categoryName) {
     serviceButton.rel = 'noopener noreferrer';
     serviceButton.dataset.url = service.url;
 
-    const favicon = document.createElement('img');
-    favicon.alt = `${service.name} favicon`;
-    favicon.className = 'service-favicon';
-    favicon.src = service.favicon_url || './favicon.ico';
-    favicon.onerror = () => { favicon.src = './favicon.ico'; };
-
     let thumbnail;
     if (service.thumbnail_url) {
         thumbnail = document.createElement('img');
@@ -296,7 +290,15 @@ function createServiceButton(service, favoritesSet, categoryName) {
 
     const serviceNameSpan = document.createElement('span');
     serviceNameSpan.className = 'service-name';
-    serviceNameSpan.textContent = service.name;
+
+    const favicon = document.createElement('img');
+    favicon.alt = `${service.name} favicon`;
+    favicon.className = 'service-favicon';
+    favicon.src = service.favicon_url || './favicon.ico';
+    favicon.onerror = () => { favicon.src = './favicon.ico'; };
+
+    serviceNameSpan.appendChild(favicon);
+    serviceNameSpan.appendChild(document.createTextNode(service.name));
 
     const serviceUrlSpan = document.createElement('span');
     serviceUrlSpan.className = 'service-url';
@@ -344,7 +346,6 @@ function createServiceButton(service, favoritesSet, categoryName) {
         toggleFavorite(service.url);
     });
 
-    serviceButton.appendChild(favicon);
     if (thumbnail) {
         serviceButton.appendChild(thumbnail);
     }
@@ -607,6 +608,7 @@ function toggleSidebar() {
     const sidebar = document.getElementById('sidebar');
     if (!sidebar) return;
     sidebar.classList.toggle('open');
+    document.body.classList.toggle('sidebar-open', sidebar.classList.contains('open'));
 }
 
 window.toggleSidebar = toggleSidebar;

--- a/styles.css
+++ b/styles.css
@@ -192,6 +192,14 @@ header {
     left: calc(200px + 1rem);
 }
 
+body.sidebar-open header,
+body.sidebar-open main,
+body.sidebar-open footer {
+    margin-left: 200px;
+    width: calc(100% - 200px);
+    transition: margin-left 0.3s ease, width 0.3s ease;
+}
+
 #header-favicon {
     display: block;
     width: 50px;
@@ -402,7 +410,7 @@ body.block-view .category {
 .service-favicon {
     width: 16px;
     height: 16px;
-    margin-right: 8px;
+    margin-right: 4px;
     vertical-align: middle;
 }
 
@@ -435,8 +443,9 @@ body.block-view .category {
     font-size: 1.4rem;
     font-weight: bold;
     margin-bottom: 0.5rem;
-    display: flex;
+    display: inline-flex;
     align-items: center;
+    gap: 0.25rem;
     word-break: break-word;
 }
 


### PR DESCRIPTION
## Summary
- embed service favicons directly in name containers to eliminate spacing
- make sidebar toggle adjust page layout using a `sidebar-open` class
- refine favicon spacing in service listings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684805148b488321b459e6ea8073cca2