### PR TITLE
Fix favorites button

### DIFF
--- a/script.js
+++ b/script.js
@@ -394,6 +394,28 @@ function clearFavorites() {
 
 window.clearFavorites = clearFavorites;
 
+function ensureClearFavoritesButton(header) {
+    let btn = header.querySelector('#clearFavoritesBtn');
+    if (!btn) {
+        btn = document.createElement('button');
+        btn.id = 'clearFavoritesBtn';
+        btn.textContent = 'Clear Favorites';
+        btn.type = 'button';
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            clearFavorites();
+        });
+        btn.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                clearFavorites();
+            }
+        });
+        header.appendChild(btn);
+    }
+}
+
 function renderFavoritesCategory() {
     const mainContainer = document.querySelector('main');
     let favoritesSection = document.getElementById('favorites');
@@ -452,24 +474,8 @@ function renderFavoritesCategory() {
         const content = document.createElement('div');
         content.className = 'category-content open';
 
-        const clearBtn = document.createElement('button');
-        clearBtn.id = 'clearFavoritesBtn';
-        clearBtn.textContent = 'Clear Favorites';
-        clearBtn.type = 'button';
-        clearBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            clearFavorites();
-        });
-        clearBtn.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                clearFavorites();
-            }
-        });
-
         favoritesSection.appendChild(header);
-        header.appendChild(clearBtn);
+        ensureClearFavoritesButton(header);
         favoritesSection.appendChild(content);
 
         const searchContainer = mainContainer.querySelector('.search-container');
@@ -479,25 +485,9 @@ function renderFavoritesCategory() {
             mainContainer.prepend(favoritesSection);
         }
     } else {
-        let btn = favoritesSection.querySelector('#clearFavoritesBtn');
-        if (!btn) {
-            btn = document.createElement('button');
-            btn.id = 'clearFavoritesBtn';
-            btn.textContent = 'Clear Favorites';
-            btn.type = 'button';
-            btn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                clearFavorites();
-            });
-            btn.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    clearFavorites();
-                }
-            });
-            const header = favoritesSection.querySelector('h2');
-            header.appendChild(btn);
+        const header = favoritesSection.querySelector('h2');
+        if (header) {
+            ensureClearFavoritesButton(header);
         }
     }
 

--- a/tests/favoritesButtonPersistence.test.js
+++ b/tests/favoritesButtonPersistence.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('favorites clear button persists after reload', () => {
+  let window, document, dom;
+
+  beforeEach(async () => {
+    const html = '<main></main>';
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const services = [
+      { name: 'Alpha', url: 'http://alpha.com', favicon_url: 'alpha.ico', category: 'Test' }
+    ];
+
+    window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(services) }));
+
+    await window.loadServices();
+
+    const star = document.querySelector('.favorite-star');
+    star.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    const stored = window.localStorage.getItem('favorites');
+    dom.window.close();
+
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+
+    const scriptEl2 = document.createElement('script');
+    scriptEl2.textContent = scriptContent;
+    document.body.appendChild(scriptEl2);
+    window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(services) }));
+    window.localStorage.setItem('favorites', stored);
+
+    await window.loadServices();
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('clear favorites button is present on reload', () => {
+    const btn = document.getElementById('clearFavoritesBtn');
+    expect(btn).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the Clear Favorites button always attaches to the favorites category
- add regression test for button persistence after reload

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848070b1b608321b04ce0fc620926e1