### PR TITLE
Fix clearFavorites storage removal

### DIFF
--- a/script.js
+++ b/script.js
@@ -389,6 +389,8 @@ function updateStars() {
 
 function clearFavorites() {
     localStorage.removeItem('favorites');
+    localStorage.removeItem('category-favorites');
+    localStorage.removeItem('view-favorites');
     updateStars();
 }
 

--- a/tests/clearFavorites.test.js
+++ b/tests/clearFavorites.test.js
@@ -42,9 +42,14 @@ describe('clearFavorites button', () => {
     expect(favSection).not.toBeNull();
     expect(star.textContent).toBe('★');
 
+    window.localStorage.setItem('category-favorites', 'closed');
+    window.localStorage.setItem('view-favorites', 'list');
+
     btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
 
     expect(window.localStorage.getItem('favorites')).toBe(null);
+    expect(window.localStorage.getItem('category-favorites')).toBe(null);
+    expect(window.localStorage.getItem('view-favorites')).toBe(null);
     favSection = document.getElementById('favorites');
     expect(favSection).toBeNull();
     expect(star.textContent).toBe('☆');


### PR DESCRIPTION
## Summary
- ensure clearing favorites removes all related localStorage keys
- test that category and view settings are cleared when favorites are removed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848116af36083218b0328baa31a9326