### PR TITLE
Fix favorites clear button enable state

### DIFF
--- a/script.js
+++ b/script.js
@@ -495,15 +495,17 @@ function renderFavoritesCategory() {
         msg.id = 'noFavoritesMsg';
         msg.textContent = 'No favorites saved.';
         content.appendChild(msg);
-        const clearBtn = header.querySelector('#clearFavoritesBtn');
-        if (clearBtn) clearBtn.disabled = true;
     } else {
         favoriteServices.forEach(service => {
             const btn = createServiceButton(service, favoritesSet);
             content.appendChild(btn);
         });
-        const clearBtn = header.querySelector('#clearFavoritesBtn');
-        if (clearBtn) clearBtn.disabled = false;
+    }
+
+    ensureClearFavoritesButton(header);
+    const btn = header.querySelector('#clearFavoritesBtn');
+    if (btn) {
+        btn.disabled = favoriteServices.length === 0;
     }
 
     // Apply collapsed or expanded state based on stored preference

--- a/tests/clearFavorites.test.js
+++ b/tests/clearFavorites.test.js
@@ -58,4 +58,17 @@ describe('clearFavorites button', () => {
     expect(btn.disabled).toBe(true);
     expect(star.textContent).toBe('☆');
   });
+
+  test('button re-enabled after favorite re-added', () => {
+    const star = document.querySelector('.favorite-star');
+    const btn = document.getElementById('clearFavoritesBtn');
+
+    btn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    expect(btn.disabled).toBe(true);
+
+    star.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    expect(btn.disabled).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure clear favorites button is present and enabled when favorites exist
- test that re-adding a favorite re-enables the clear button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481852ba548321adc9e4ffbb0224b5