### PR TITLE
Fix: Default Favorites section to expanded when empty

### DIFF
--- a/tests/favorites.test.js
+++ b/tests/favorites.test.js
@@ -38,6 +38,19 @@ describe('favorites management', () => {
     const clearBtn = document.getElementById('clearFavoritesBtn');
     expect(clearBtn.disabled).toBe(true);
     expect(favSection.querySelectorAll('.service-button').length).toBe(0);
+
+    // New assertions:
+    const content = favSection.querySelector('.category-content');
+    const header = favSection.querySelector('h2');
+    expect(content.classList.contains('open')).toBe(true);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(content.style.maxHeight).not.toBe('0px');
+    // MAX_CATEGORY_HEIGHT is defined in script.js, need to ensure test environment can access a similar value or check against it if possible.
+    // For simplicity, checking if it's greater than 0 is a good start, as scrollHeight of #noFavoritesMsg should make it > 0.
+    // The actual height will be Math.min(content.scrollHeight, MAX_CATEGORY_HEIGHT from script.js)
+    // Let's assume scrollHeight of the message is at least 1.
+    expect(parseInt(content.style.maxHeight)).toBeGreaterThan(0);
+    expect(window.localStorage.getItem('category-favorites')).toBe('open');
   });
 
   test('adding and removing favorites updates storage and UI', () => {


### PR DESCRIPTION
I modified `renderFavoritesCategory` in `script.js` to ensure that the Favorites section defaults to an expanded state if it contains no items, or if no previous collapsed/expanded state was stored in localStorage. This addresses an issue where an empty and collapsed Favorites section could appear hidden to you.

If the Favorites section is empty, or if no 'category-favorites' state is in localStorage, it will now be opened by default, and its state will be saved as 'open' in localStorage. If the Favorites section contains items, its previously stored state (open or closed) will be respected.

I also updated `tests/favorites.test.js` to include assertions for this new default behavior, checking that the 'open' class is applied, aria-attributes are correct, maxHeight is set appropriately, and localStorage is updated when the Favorites section is initially empty.