### PR TITLE
Add multi-tag search support

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,8 @@
     </header>
     <main>
         <div class="search-container">
-            <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" />
+            <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" list="tagOptions" />
+            <datalist id="tagOptions"></datalist>
         </div>
         <p id="noResults" class="no-results" hidden>No results found.</p>
         <!-- Service listings will be dynamically injected here by script.js -->

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -86,4 +86,22 @@ describe('search filtering', () => {
     expect(cat1.style.display).toBe('');
     expect(cat2.style.display).toBe('');
   });
+
+  test('supports filtering by multiple tags', () => {
+    const buttons = document.querySelectorAll('.service-button');
+    const [alphaBtn, betaBtn] = buttons;
+    const cat1 = document.getElementById('cat1');
+
+    searchInput.value = 'news, cat1';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    expect(alphaBtn.style.display).toBe('flex');
+    expect(betaBtn.style.display).toBe('none');
+    expect(cat1.style.display).toBe('');
+
+    searchInput.value = 'news, support';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    buttons.forEach(btn => expect(btn.style.display).toBe('none'));
+  });
 });


### PR DESCRIPTION
## Summary
- enable comma-separated tag queries in `setupSearch`
- generate datalist of all service tags
- expose tag dropdown in the search bar
- extend tests for multi-tag filtering

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f1a28ab88321a77697fac376a483