### PR TITLE
Fix manifest start_url

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "AI Services Dashboard",
   "short_name": "AI Dashboard",
-  "start_url": "../index.html",
-  "scope": "../",
+  "start_url": "index.html",
+  "scope": "./",
   "display": "standalone",
   "theme_color": "#1a1a1a",
   "background_color": "#1a1a1a",


### PR DESCRIPTION
## Summary
- point PWA start_url at index.html

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fe7ba76c83219869de6cf9991137