### PR TITLE
Update service worker globals

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -8,6 +8,8 @@ const URLS_TO_CACHE = [
   './favicon.ico',
   './public/manifest.json'
 ];
+self.CACHE_NAME = CACHE_NAME;
+self.URLS_TO_CACHE = URLS_TO_CACHE;
 
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- expose `CACHE_NAME` and `URLS_TO_CACHE` on `self` so tests can access them

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490156b714832180b7c19b4923b525