### PR TITLE
Update service worker URL handling

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -45,10 +45,11 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
-  const requestUrl = new URL(event.request.url);
+  // const requestUrl = new URL(event.request.url);
+  const requestUrl = event.request.url;
 
   // Network first for script.js and services.json
-  if (requestUrl.pathname.endsWith('/script.js') || requestUrl.pathname.endsWith('/services.json')) {
+  if (requestUrl.endsWith('/script.js') || requestUrl.endsWith('/services.json')) {
     event.respondWith(
       fetch(event.request).catch(() => caches.match(event.request))
     );


### PR DESCRIPTION
## Summary
- check service worker URLs using string `.endsWith` rather than parsing with `URL`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849036e20788321b7b50a3e88762878