### PR TITLE
Fix service worker cache exposure

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -8,8 +8,8 @@ const URLS_TO_CACHE = [
   './favicon.ico',
   './public/manifest.json'
 ];
-self.CACHE_NAME = CACHE_NAME;
-self.URLS_TO_CACHE = URLS_TO_CACHE;
+self.CACHE_NAME = globalThis.CACHE_NAME = CACHE_NAME;
+self.URLS_TO_CACHE = globalThis.URLS_TO_CACHE = URLS_TO_CACHE;
 
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- expose service worker cache constants on both `self` and `globalThis`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849055c1318832185c279accc4afbac