### PR TITLE
Fix: Ensure 'Clear Favorites' button is always small and standardize …

### DIFF
--- a/script.js
+++ b/script.js
@@ -412,6 +412,7 @@ function ensureClearFavoritesButton(header) {
     let btn = header.querySelector('#clearFavoritesBtn');
     if (!btn) {
         btn = document.createElement('button');
+        btn.classList.add('btn-small');
         btn.id = 'clearFavoritesBtn';
         btn.textContent = 'Clear Favorites';
         btn.type = 'button';

--- a/styles.css
+++ b/styles.css
@@ -122,12 +122,15 @@ header {
     border: 2px solid var(--text-color);
     color: var(--text-color);
     font-family: var(--font-family);
-    font-size: 0.6rem;
-    padding: 0.1rem 0.2rem;
     border-radius: 5px;
     cursor: pointer;
     margin-left: 0.5rem;
     margin: 0.5rem;
+}
+
+.btn-small {
+    font-size: 0.6rem;
+    padding: 0.1rem 0.2rem;
 }
 
 #sidebar {
@@ -410,7 +413,6 @@ body.block-view .category {
 .service-favicon {
     width: 16px;
     height: 16px;
-    margin-right: 4px;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
…title indentation.

This commit addresses two UI consistency issues:

1. 'Clear Favorites' Button Size:
   - The 'Clear Favorites' button would sometimes appear larger than intended, especially after page refreshes.
   - Introduced a CSS class `.btn-small` with `font-size: 0.6rem` and `padding: 0.1rem 0.2rem`.
   - Modified `script.js` to add this class to the button upon creation.
   - Removed the redundant size-specific styles from the `#clearFavoritesBtn` ID selector in `styles.css`, relying now on the `.btn-small` class for sizing. This ensures the button consistently maintains its small appearance.

2. Service Title Indentation:
   - The first listing in the '3D' category ("3D AI Studio") reportedly had an inconsistent title indent.
   - Removed the `margin-right: 4px;` from the `.service-favicon` CSS rule.
   - The spacing between the favicon and the service name text is now solely controlled by the `gap: 0.25rem;` property on the parent `.service-name` container. This change promotes uniform spacing and alignment for all service titles.