### PR TITLE
Fix favorite star positioning

### DIFF
--- a/script.js
+++ b/script.js
@@ -358,14 +358,13 @@ function createServiceButton(service, favoritesSet, categoryName) {
         toggleFavorite(service.url);
     });
 
-    serviceUrlSpan.appendChild(star);
-
     if (thumbnail) {
         serviceButton.appendChild(thumbnail);
     }
     serviceButton.appendChild(serviceNameSpan);
     serviceButton.appendChild(serviceUrlSpan);
     serviceButton.appendChild(serviceTagsSpan);
+    serviceButton.appendChild(star);
 
     return serviceButton;
 }

--- a/styles.css
+++ b/styles.css
@@ -389,6 +389,7 @@ body.block-view .category {
     flex-direction: column;
     background: var(--button-gradient);
     padding: 0.75rem;
+    padding-right: 2rem; /* space for favorite star */
     width: 100%;
     box-sizing: border-box;
     border: 2px solid var(--accent-color);
@@ -430,6 +431,9 @@ body.block-view .category {
     cursor: pointer;
     font-size: 1.5rem;
     color: #ccc;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.25rem;
 }
 .favorite-star:focus {
     outline: 2px solid var(--text-color);


### PR DESCRIPTION
## Summary
- absolutely position favorite star icons on service cards
- reserve space for the star so it doesn't overlap text
- attach star element to the card instead of within the URL span

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497a5ade208321ac3562e035509dbd