### PR TITLE
Fix layout overflow with scrollbar widths

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,7 @@
     --category-max-height: 400px;
     --scroll-track: #0a0a0a;
     --scroll-thumb: #5faa6f;
+    --scrollbar-width: 8px;
     --card-min-width: 300px;
     --category-min-width: 300px;
 }
@@ -41,6 +42,7 @@ body.light-mode {
     --font-family: 'Roboto Mono', monospace;
     --scroll-track: #f0f0f0;
     --scroll-thumb: #a8d5a8;
+    --scrollbar-width: 8px;
     --card-min-width: 300px;
     --category-min-width: 300px;
 }
@@ -55,7 +57,7 @@ html.light-mode {
     box-sizing: border-box;
 }
 ::-webkit-scrollbar {
-    width: 8px;
+    width: var(--scrollbar-width);
 }
 ::-webkit-scrollbar-track {
     background: var(--scroll-track);
@@ -291,6 +293,7 @@ body.block-view .category {
 .category h2 {
     background: var(--section-gradient);
     padding: 1rem;
+    padding-right: calc(1rem + var(--scrollbar-width));
     margin: 0;
     cursor: pointer;
     font-size: 1.8rem;
@@ -363,6 +366,7 @@ body.block-view .category {
     max-height: var(--category-max-height);
     overflow-y: auto;
     overflow-x: hidden;
+    padding-right: calc(1rem + var(--scrollbar-width));
 }
 
 .category.list-view .category-content {


### PR DESCRIPTION
## Summary
- add `--scrollbar-width` variable
- reserve space for scrollbars in category headings and content

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497f34fa8c832189ca1a61be75c65b