### PR TITLE
Fix star clipping in double tile view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -399,6 +399,7 @@ body.block-view .category {
     background: var(--button-gradient);
     padding: 0.75rem;
     padding-right: 2rem; /* space for favorite star */
+    width: 100%;
     max-width: var(--card-max-width);
     margin: 0 auto;
     min-width: 0;


### PR DESCRIPTION
## Summary
- ensure service tiles don't overflow narrow category columns

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684983075e9c8321800647d227d9ea54