### PR TITLE
Adjust typography sizes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,7 @@ html.light-mode {
 
 header {
     background: var(--header-gradient);
-    padding: 2rem;
+    padding: 1.5rem;
     text-align: center;
     border-bottom: 2px solid var(--text-color);
     box-shadow: 0 0 10px rgba(102, 178, 102, 0.3);
@@ -217,7 +217,7 @@ body.sidebar-open footer {
 }
 
 header h1 {
-    font-size: 3rem;
+    font-size: 2.5rem;
     margin: 0;
     text-transform: uppercase;
     letter-spacing: 3px;
@@ -294,11 +294,11 @@ body.block-view .category {
 
 .category h2 {
     background: var(--section-gradient);
-    padding: 1rem;
+    padding: 0.85rem;
     padding-right: calc(1rem + var(--scrollbar-width));
     margin: 0;
     cursor: pointer;
-    font-size: 1.8rem;
+    font-size: 1.6rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -477,9 +477,9 @@ body.block-view .category {
 }
 
 .service-name {
-    font-size: 1.2rem;
+    font-size: 1rem;
     font-weight: bold;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4rem;
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
@@ -487,7 +487,7 @@ body.block-view .category {
 }
 
 .service-url {
-    font-size: 0.9rem;
+    font-size: 0.8rem;
     word-break: break-all;
     display: inline-flex;
     align-items: center;
@@ -504,7 +504,7 @@ body.block-view .category {
 
 footer {
     background: var(--footer-gradient);
-    padding: 1rem;
+    padding: 0.8rem;
     text-align: center;
     border-top: 2px solid var(--text-color);
     box-shadow: 0 -2px 8px rgba(102, 178, 102, 0.2);
@@ -512,8 +512,8 @@ footer {
 }
 
 footer p {
-    margin: 0.5rem 0;
-    font-size: 1.2rem;
+    margin: 0.4rem 0;
+    font-size: 1rem;
 }
 
 footer a {
@@ -521,7 +521,7 @@ footer a {
 }
 
 footer .thanks {
-    font-size: 1rem;
+    font-size: 0.9rem;
     color: var(--thanks-color);
 }
 
@@ -541,11 +541,11 @@ footer .thanks a:hover {
     }
 
     header h1 {
-        font-size: 2rem;
+        font-size: 1.6rem;
     }
 
     .category h2 {
-        font-size: 1.4rem;
+        font-size: 1.2rem;
     }
 
     #searchInput {


### PR DESCRIPTION
## Summary
- reduce heading and footer font sizes for a more compact look
- tweak padding and margins to match the smaller typography
- update responsive CSS rules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684995be73a083218047c8d32d2dffc5