### PR TITLE
Add mobile view toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The AI Services Dashboard is a static webpage designed to provide a curated list
 *   **Alphabetical Sorting:** Categories and services are automatically sorted alphabetically when `script.js` dynamically loads `services.json`.
 *   **Favorites:** Mark services with the star icon to quickly access them in a dedicated "Favorites" category that persists using `localStorage`.
 *   **Category View Toggle:** Each category can switch between grid and list layouts independently, and the choice is remembered.
+*   **Mobile View Toggle:** Force a single-column layout regardless of screen size with the "Mobile View" button.
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
         <h1 class="typing-effect">AI Services Dashboard</h1>
         <button id="themeToggle" onclick="toggleTheme()" aria-label="Toggle theme">Toggle Theme</button>
         <button id="viewToggle" onclick="toggleView()" aria-label="Toggle category view">Toggle View</button>
+        <button id="mobileToggle" onclick="toggleMobileView()" aria-label="Toggle mobile view">Mobile View</button>
         <button id="installBtn" aria-label="Install app">Install App</button>
     </header>
     <main>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ const MAX_CATEGORY_HEIGHT =
 document.addEventListener('DOMContentLoaded', () => {
     applySavedTheme();
     applySavedView();
+    applySavedMobileView();
     updateToggleButtons();
 
     buildSidebar();
@@ -605,6 +606,13 @@ function applySavedView() {
     }
 }
 
+function applySavedMobileView() {
+    const saved = localStorage.getItem('mobileView');
+    if (saved === 'on') {
+        document.body.classList.add('mobile-view');
+    }
+}
+
 function toggleView() {
     const isBlock = document.body.classList.toggle('block-view');
     localStorage.setItem('view', isBlock ? 'block' : 'list');
@@ -612,6 +620,14 @@ function toggleView() {
 }
 
 window.toggleView = toggleView;
+
+function toggleMobileView() {
+    const isMobile = document.body.classList.toggle('mobile-view');
+    localStorage.setItem('mobileView', isMobile ? 'on' : 'off');
+    updateToggleButtons();
+}
+
+window.toggleMobileView = toggleMobileView;
 
 function toggleCategoryView(categoryId) {
     const section = document.getElementById(categoryId);
@@ -634,6 +650,10 @@ function updateToggleButtons() {
     const viewBtn = document.getElementById('viewToggle');
     if (viewBtn) {
         viewBtn.classList.toggle('active', document.body.classList.contains('block-view'));
+    }
+    const mobileBtn = document.getElementById('mobileToggle');
+    if (mobileBtn) {
+        mobileBtn.classList.toggle('active', document.body.classList.contains('mobile-view'));
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -89,12 +89,26 @@ header {
     margin-top: 1rem;
 }
 #themeToggle.active,
-#viewToggle.active {
+#viewToggle.active,
+#mobileToggle.active {
     background: var(--accent-color);
     color: var(--bg-color);
 }
 
 #viewToggle {
+    background: none;
+    border: 2px solid var(--text-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: 0.8rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 5px;
+    cursor: pointer;
+    margin-top: 1rem;
+    margin-left: 0.5rem;
+}
+
+#mobileToggle {
     background: none;
     border: 2px solid var(--text-color);
     color: var(--text-color);
@@ -466,6 +480,7 @@ body.block-view .category {
 
 #themeToggle:hover,
 #viewToggle:hover,
+#mobileToggle:hover,
 #installBtn:hover,
 #clearFavoritesBtn:hover,
 #sidebarToggle:hover,
@@ -541,6 +556,22 @@ footer .thanks a:hover {
 }
 
 /* Responsive Design */
+
+body.mobile-view .category-content {
+    grid-template-columns: 1fr;
+}
+
+body.mobile-view header h1 {
+    font-size: 1.6rem;
+}
+
+body.mobile-view .category h2 {
+    font-size: 1.2rem;
+}
+
+body.mobile-view #searchInput {
+    width: 90%;
+}
 @media (max-width: 768px) {
     .category-content {
         grid-template-columns: 1fr;

--- a/tests/mobileToggle.test.js
+++ b/tests/mobileToggle.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('toggleMobileView', () => {
+  let window, document, dom;
+
+  beforeEach(() => {
+    dom = new JSDOM('<body></body>', { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('toggles mobile-view class and localStorage state', () => {
+    expect(document.body.classList.contains('mobile-view')).toBe(false);
+    expect(window.localStorage.getItem('mobileView')).toBe(null);
+
+    window.toggleMobileView();
+
+    expect(document.body.classList.contains('mobile-view')).toBe(true);
+    expect(window.localStorage.getItem('mobileView')).toBe('on');
+
+    window.toggleMobileView();
+
+    expect(document.body.classList.contains('mobile-view')).toBe(false);
+    expect(window.localStorage.getItem('mobileView')).toBe('off');
+  });
+});


### PR DESCRIPTION
## Summary
- add Mobile View button in header
- implement `.mobile-view` class to emulate mobile layout
- add `toggleMobileView()` function with localStorage support
- highlight new feature in README
- test mobile view toggle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684997117be4832192dd6f0d00bfd635