### PR TITLE
Hide view toggle in mobile layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -581,7 +581,16 @@ body.mobile-view .category h2 {
 body.mobile-view #searchInput {
     width: 90%;
 }
+
+/* Hide the view toggle when mobile layout is active */
+body.mobile-view #viewToggle {
+    display: none;
+}
+
 @media (max-width: 768px) {
+    #viewToggle {
+        display: none;
+    }
     .category-content {
         grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## Summary
- hide the View Toggle button when viewing the site in mobile layout to avoid confusion

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499aee26d483219c9c229db4c64349