### PR TITLE
Add tag search hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         <div class="search-container">
             <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" list="tagOptions" />
             <datalist id="tagOptions"></datalist>
+            <small class="tag-hint">Search by tag using "tag1,tag2"</small>
         </div>
         <p id="noResults" class="no-results" hidden>No results found.</p>
         <!-- Service listings will be dynamically injected here by script.js -->

--- a/styles.css
+++ b/styles.css
@@ -276,6 +276,13 @@ body.block-view .category {
     text-align: center;
 }
 
+.tag-hint {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.8rem;
+    color: var(--thanks-color);
+}
+
 #searchInput {
     background: var(--content-bg);
     backdrop-filter: blur(3px);


### PR DESCRIPTION
## Summary
- add hint text to search container in `index.html`
- style the `.tag-hint` element in `styles.css`

## Testing
- `npm install --silent`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a467253c483219e989ae7fd7896ec