### PR TITLE
Add copy link button

### DIFF
--- a/script.js
+++ b/script.js
@@ -317,6 +317,24 @@ function createServiceButton(service, favoritesSet, categoryName) {
     serviceUrlSpan.className = 'service-url';
     serviceUrlSpan.textContent = service.url;
 
+    const copyBtn = document.createElement('button');
+    copyBtn.type = 'button';
+    copyBtn.className = 'copy-link';
+    copyBtn.textContent = '📋';
+    copyBtn.setAttribute('aria-label', `Copy ${service.name} URL`);
+    copyBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        navigator.clipboard.writeText(service.url).then(() => {
+            const original = copyBtn.textContent;
+            copyBtn.textContent = 'Copied!';
+            setTimeout(() => {
+                copyBtn.textContent = original;
+            }, 1000);
+        });
+    });
+    serviceUrlSpan.appendChild(copyBtn);
+
     const serviceTagsSpan = document.createElement('span');
     serviceTagsSpan.className = 'service-tags';
     serviceTagsSpan.style.display = 'none';

--- a/styles.css
+++ b/styles.css
@@ -531,6 +531,19 @@ body.block-view .category {
     gap: 0.25rem;
 }
 
+.copy-link {
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.8rem;
+}
+.copy-link:focus {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+}
+
 .category.list-view .service-url {
     margin-left: auto;
 }

--- a/tests/copyButton.test.js
+++ b/tests/copyButton.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('createServiceButton copy link', () => {
+  test('service button contains copy link button', async () => {
+    const html = '<main></main>';
+    const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    const { window } = dom;
+    const { document } = window;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    const servicesData = [
+      { name: 'Alpha', url: 'http://alpha.com', favicon_url: 'alpha.ico', category: 'Test' }
+    ];
+
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(servicesData) })
+    );
+
+    await window.loadServices();
+
+    const copyBtn = document.querySelector('.service-button .copy-link');
+    expect(copyBtn).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- allow quick copy of service URLs
- style new copy link button
- test that service buttons include a copy link option

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4897915c8321bf0e8cc23f8cb728