### PR TITLE
Add expand/collapse all categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
             <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" list="tagOptions" />
             <datalist id="tagOptions"></datalist>
             <small class="tag-hint">Search by tag using "tag1,tag2"</small>
+            <button id="expandAllBtn" onclick="expandAllCategories()" type="button">Expand All</button>
+            <button id="collapseAllBtn" onclick="collapseAllCategories()" type="button">Collapse All</button>
         </div>
         <p id="noResults" class="no-results" hidden>No results found.</p>
         <!-- Service listings will be dynamically injected here by script.js -->

--- a/script.js
+++ b/script.js
@@ -284,6 +284,24 @@ function toggleCategory(header) {
     }
 }
 
+function expandAllCategories() {
+    document.querySelectorAll('.category h2').forEach(header => {
+        const content = header.parentElement.querySelector('.category-content');
+        if (content && !content.classList.contains('open')) {
+            toggleCategory(header);
+        }
+    });
+}
+
+function collapseAllCategories() {
+    document.querySelectorAll('.category h2').forEach(header => {
+        const content = header.parentElement.querySelector('.category-content');
+        if (content && content.classList.contains('open')) {
+            toggleCategory(header);
+        }
+    });
+}
+
 function createServiceButton(service, favoritesSet, categoryName) {
     const serviceButton = document.createElement('a');
     serviceButton.className = 'service-button';
@@ -727,4 +745,6 @@ function populateTagDropdown() {
 }
 
 window.populateTagDropdown = populateTagDropdown;
+window.expandAllCategories = expandAllCategories;
+window.collapseAllCategories = collapseAllCategories;
 

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,20 @@ header {
     display: none;
 }
 
+#expandAllBtn,
+#collapseAllBtn {
+    background: none;
+    border: 2px solid var(--text-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: 0.8rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 5px;
+    cursor: pointer;
+    margin-top: 0.5rem;
+    margin-left: 0.5rem;
+}
+
 #clearFavoritesBtn {
     background: none;
     border: 2px solid var(--text-color);
@@ -498,6 +512,8 @@ body.block-view .category {
 #viewToggle:hover,
 #mobileToggle:hover,
 #installBtn:hover,
+#expandAllBtn:hover,
+#collapseAllBtn:hover,
 #clearFavoritesBtn:hover,
 #sidebarToggle:hover,
 .category-view-toggle:hover,

--- a/tests/expandCollapseAllCategories.test.js
+++ b/tests/expandCollapseAllCategories.test.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('expandAllCategories and collapseAllCategories', () => {
+  let window, document, dom;
+
+  beforeEach(() => {
+    const html = `
+      <section class="category" id="one">
+        <h2 aria-expanded="false">One <span class="chevron">▼</span></h2>
+        <div class="category-content"></div>
+      </section>
+      <section class="category" id="two">
+        <h2 aria-expanded="false">Two <span class="chevron">▼</span></h2>
+        <div class="category-content"></div>
+      </section>
+    `;
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+  });
+
+  afterEach(() => {
+    window.close();
+  });
+
+  test('expandAllCategories opens all categories', () => {
+    window.expandAllCategories();
+    const headers = document.querySelectorAll('.category h2');
+    headers.forEach(header => {
+      const content = header.parentElement.querySelector('.category-content');
+      expect(content.classList.contains('open')).toBe(true);
+      expect(header.getAttribute('aria-expanded')).toBe('true');
+      const id = header.parentElement.id;
+      expect(window.localStorage.getItem(`category-${id}`)).toBe('open');
+    });
+  });
+
+  test('collapseAllCategories closes all categories', () => {
+    // first open them so we can test collapse
+    const headers = document.querySelectorAll('.category h2');
+    headers.forEach(header => window.toggleCategory(header));
+
+    window.collapseAllCategories();
+
+    headers.forEach(header => {
+      const content = header.parentElement.querySelector('.category-content');
+      expect(content.classList.contains('open')).toBe(false);
+      expect(header.getAttribute('aria-expanded')).toBe('false');
+      const id = header.parentElement.id;
+      expect(window.localStorage.getItem(`category-${id}`)).toBe('closed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `expandAllCategories` and `collapseAllCategories`
- expose new functions globally
- add control buttons to UI
- style the new buttons
- test expand/collapse helpers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a496818408321a52a85529f7690d6