### PR TITLE
Implement sidebar link highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 let allServices = [];
 let deferredPrompt = null;
+let sidebarObserver = null;
 const MAX_CATEGORY_HEIGHT =
     parseInt(
         getComputedStyle(document.documentElement).getPropertyValue(
@@ -14,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateToggleButtons();
 
     buildSidebar();
+    setupSidebarHighlighting();
 
     const sidebarToggle = document.getElementById('sidebarToggle');
     if (sidebarToggle) {
@@ -186,6 +188,7 @@ async function loadServices() {
         });
 
         buildSidebar();
+        setupSidebarHighlighting();
 
         // Re-initialize search functionality
         setupSearch();
@@ -727,6 +730,30 @@ function toggleSidebar() {
 window.toggleSidebar = toggleSidebar;
 window.buildSidebar = buildSidebar;
 
+function setupSidebarHighlighting() {
+    if (sidebarObserver) {
+        sidebarObserver.disconnect();
+    }
+    const sidebar = document.getElementById('sidebar');
+    if (!sidebar || !('IntersectionObserver' in window)) return;
+    const links = sidebar.querySelectorAll('a[href^="#"]');
+    const sections = document.querySelectorAll('.category');
+    if (!links.length || !sections.length) return;
+
+    sidebarObserver = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.intersectionRatio >= 0.5) {
+                const id = entry.target.id;
+                links.forEach(link => {
+                    link.classList.toggle('active', link.getAttribute('href') === `#${id}`);
+                });
+            }
+        });
+    }, { threshold: 0.5 });
+
+    sections.forEach(section => sidebarObserver.observe(section));
+}
+
 function populateTagDropdown() {
     const datalist = document.getElementById('tagOptions');
     if (!datalist) return;
@@ -747,4 +774,5 @@ function populateTagDropdown() {
 window.populateTagDropdown = populateTagDropdown;
 window.expandAllCategories = expandAllCategories;
 window.collapseAllCategories = collapseAllCategories;
+window.setupSidebarHighlighting = setupSidebarHighlighting;
 

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,12 @@ header {
     position: relative;
 }
 
+#sidebar a.active {
+    background: var(--button-gradient);
+    border-radius: 5px;
+    color: var(--bg-color);
+}
+
 #sidebar a::before {
     content: "\2022"; /* bullet */
     position: absolute;


### PR DESCRIPTION
## Summary
- highlight category links as sections scroll into view
- export `setupSidebarHighlighting` for reuse
- style active sidebar links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4a65392c8321a69183b8ae620b45