### PR TITLE
Add update notification for service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,11 +44,9 @@
         <p>© 2025 <a href="https://www.github.com/NathanNeurotic/" target="_blank" rel="noopener noreferrer">NathanNeurotic</a>. All rights reserved.</p>
         <p><a href="https://www.github.com/NathanNeurotic/AI" target="_blank" rel="noopener noreferrer">GitHub Repository</a></p>
     </footer>
+    <div id="updateNotification" hidden>
+        New version available <button id="refreshBtn">Refresh</button>
+    </div>
     <script src="./script.js"></script>
-    <script>
-        if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('service-worker.js');
-        }
-    </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -69,6 +69,41 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.querySelector('main')) {
         loadServices();
     }
+
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('service-worker.js').then(reg => {
+            function notify(worker) {
+                const bar = document.getElementById('updateNotification');
+                if (!bar) return;
+                bar.hidden = false;
+                const refresh = document.getElementById('refreshBtn');
+                if (refresh) {
+                    refresh.onclick = () => {
+                        worker.postMessage({ type: 'SKIP_WAITING' });
+                    };
+                }
+            }
+
+            if (reg.waiting) {
+                notify(reg.waiting);
+            }
+
+            reg.addEventListener('updatefound', () => {
+                const newWorker = reg.installing;
+                if (newWorker) {
+                    newWorker.addEventListener('statechange', () => {
+                        if (newWorker.state === 'installed' && reg.waiting) {
+                            notify(reg.waiting);
+                        }
+                    });
+                }
+            });
+
+            navigator.serviceWorker.addEventListener('controllerchange', () => {
+                window.location.reload();
+            });
+        });
+    }
 });
 
 async function loadServices() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -61,3 +61,9 @@ self.addEventListener('fetch', event => {
     caches.match(event.request).then(response => response || fetch(event.request))
   );
 });
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -653,3 +653,18 @@ body.mobile-view #viewToggle {
         width: 90%;
     }
 }
+
+#updateNotification {
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--accent-color);
+    color: var(--bg-color);
+    padding: 0.5rem 1rem;
+    border-radius: 5px;
+    display: none;
+}
+#updateNotification[hidden] {
+    display: none;
+}

--- a/tests/serviceWorker.test.js
+++ b/tests/serviceWorker.test.js
@@ -141,4 +141,12 @@ describe('service worker', () => {
     expect(caches.match).toHaveBeenCalledWith(fetchEventFail.request);
     expect(fallback).toBe(cacheStore.get(toAbsolute('./services.json')));
   });
+
+  test('message SKIP_WAITING triggers skipWaiting', () => {
+    const ctx = setupServiceWorker();
+    const { listeners, self } = ctx;
+    const evt = { data: { type: 'SKIP_WAITING' } };
+    listeners['message'](evt);
+    expect(self.skipWaiting).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- show update notification banner in `index.html`
- handle updatefound/controllerchange events when registering service worker
- listen for SKIP_WAITING message in service worker
- style the update banner
- test service worker message handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4c191adc8321a4d5a873eda0b0d6