### PR TITLE
Add desktop view toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link rel="icon" type="image/x-icon" href="./favicon.ico" />
     <link rel="apple-touch-icon" href="./public/icon-192x192.png">
 </head>
-<body>
+<body class="desktop-view">
     <nav id="sidebar"></nav>
     <button id="sidebarToggle" aria-label="Toggle sidebar" title="Toggle sidebar">☰</button>
     <header>

--- a/script.js
+++ b/script.js
@@ -688,6 +688,8 @@ function applySavedMobileView() {
     const saved = localStorage.getItem('mobileView');
     if (saved === 'on') {
         document.body.classList.add('mobile-view');
+    } else {
+        document.body.classList.add('desktop-view');
     }
 }
 
@@ -700,7 +702,9 @@ function toggleView() {
 window.toggleView = toggleView;
 
 function toggleMobileView() {
-    const isMobile = document.body.classList.toggle('mobile-view');
+    const isMobile = !document.body.classList.contains('mobile-view');
+    document.body.classList.toggle('mobile-view', isMobile);
+    document.body.classList.toggle('desktop-view', !isMobile);
     localStorage.setItem('mobileView', isMobile ? 'on' : 'off');
     updateToggleButtons();
 }
@@ -739,7 +743,10 @@ function updateToggleButtons() {
     }
     const mobileBtn = document.getElementById('mobileToggle');
     if (mobileBtn) {
-        mobileBtn.classList.toggle('active', document.body.classList.contains('mobile-view'));
+        const isMobile = document.body.classList.contains('mobile-view');
+        mobileBtn.classList.toggle('active', isMobile);
+        mobileBtn.title = isMobile ? 'Switch to desktop view' : 'Switch to mobile view';
+        mobileBtn.setAttribute('aria-label', mobileBtn.title);
         mobileBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>';
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -649,10 +649,10 @@ body.mobile-view #viewToggle {
 }
 
 @media (max-width: 768px) {
-    #viewToggle {
+    body:not(.desktop-view) #viewToggle {
         display: none;
     }
-    .category-content {
+    body:not(.desktop-view) .category-content {
         grid-template-columns: 1fr;
     }
 

--- a/tests/mobileToggle.test.js
+++ b/tests/mobileToggle.test.js
@@ -21,18 +21,21 @@ describe('toggleMobileView', () => {
     window.close();
   });
 
-  test('toggles mobile-view class and localStorage state', () => {
+  test('toggles view classes and localStorage state', () => {
     expect(document.body.classList.contains('mobile-view')).toBe(false);
+    expect(document.body.classList.contains('desktop-view')).toBe(true);
     expect(window.localStorage.getItem('mobileView')).toBe(null);
 
     window.toggleMobileView();
 
     expect(document.body.classList.contains('mobile-view')).toBe(true);
+    expect(document.body.classList.contains('desktop-view')).toBe(false);
     expect(window.localStorage.getItem('mobileView')).toBe('on');
 
     window.toggleMobileView();
 
     expect(document.body.classList.contains('mobile-view')).toBe(false);
+    expect(document.body.classList.contains('desktop-view')).toBe(true);
     expect(window.localStorage.getItem('mobileView')).toBe('off');
   });
 });


### PR DESCRIPTION
## Summary
- introduce default `desktop-view` class on `<body>`
- toggle `desktop-view` and `mobile-view` classes in script.js
- update mobile toggle button metadata
- only apply some mobile styles when not in desktop view
- revise tests for new view logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ba3a967808321b07afa693774b0b9