### PR TITLE
Fix mobile view persistence

### DIFF
--- a/script.js
+++ b/script.js
@@ -685,12 +685,7 @@ function applySavedView() {
 }
 
 function applySavedMobileView() {
-    const saved = localStorage.getItem('mobileView');
-    if (saved === 'on') {
-        document.body.classList.add('mobile-view');
-    } else {
-        document.body.classList.add('desktop-view');
-    }
+    document.body.classList.add('desktop-view');
 }
 
 function toggleView() {
@@ -705,7 +700,6 @@ function toggleMobileView() {
     const isMobile = !document.body.classList.contains('mobile-view');
     document.body.classList.toggle('mobile-view', isMobile);
     document.body.classList.toggle('desktop-view', !isMobile);
-    localStorage.setItem('mobileView', isMobile ? 'on' : 'off');
     updateToggleButtons();
 }
 

--- a/tests/mobileToggle.test.js
+++ b/tests/mobileToggle.test.js
@@ -21,7 +21,7 @@ describe('toggleMobileView', () => {
     window.close();
   });
 
-  test('toggles view classes and localStorage state', () => {
+  test('toggles view classes', () => {
     expect(document.body.classList.contains('mobile-view')).toBe(false);
     expect(document.body.classList.contains('desktop-view')).toBe(true);
     expect(window.localStorage.getItem('mobileView')).toBe(null);
@@ -30,12 +30,12 @@ describe('toggleMobileView', () => {
 
     expect(document.body.classList.contains('mobile-view')).toBe(true);
     expect(document.body.classList.contains('desktop-view')).toBe(false);
-    expect(window.localStorage.getItem('mobileView')).toBe('on');
+    expect(window.localStorage.getItem('mobileView')).toBe(null);
 
     window.toggleMobileView();
 
     expect(document.body.classList.contains('mobile-view')).toBe(false);
     expect(document.body.classList.contains('desktop-view')).toBe(true);
-    expect(window.localStorage.getItem('mobileView')).toBe('off');
+    expect(window.localStorage.getItem('mobileView')).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary
- default to desktop view on every load
- stop storing mobile view setting in localStorage
- update mobile view tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c315425e48321a8cc019e60a4ffc2