### PR TITLE
Implement persistent mobile view

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The AI Services Dashboard is a static webpage designed to provide a curated list
 *   **Category View Toggle:** Each category can switch between grid and list layouts independently, and the choice is remembered.
 *   **Mobile View Toggle:** Force a single-column layout regardless of screen size with the "Mobile View" button.
 *   **Desktop View Toggle:** Force the multi-column layout with the "Desktop View" button.
+*   **View Preference Persistence:** Your mobile or desktop choice is saved in `localStorage` and reapplied on future visits.
 
 ## Getting Started
 

--- a/script.js
+++ b/script.js
@@ -685,7 +685,10 @@ function applySavedView() {
 }
 
 function applySavedMobileView() {
-    document.body.classList.add('desktop-view');
+    const saved = localStorage.getItem('mobileView');
+    const isMobile = saved === 'mobile';
+    document.body.classList.toggle('mobile-view', isMobile);
+    document.body.classList.toggle('desktop-view', !isMobile);
 }
 
 function toggleView() {
@@ -700,6 +703,7 @@ function toggleMobileView() {
     const isMobile = !document.body.classList.contains('mobile-view');
     document.body.classList.toggle('mobile-view', isMobile);
     document.body.classList.toggle('desktop-view', !isMobile);
+    localStorage.setItem('mobileView', isMobile ? 'mobile' : 'desktop');
     updateToggleButtons();
 }
 
@@ -709,6 +713,7 @@ function toggleDesktopView() {
     const isDesktop = !document.body.classList.contains('desktop-view');
     document.body.classList.toggle('desktop-view', isDesktop);
     document.body.classList.toggle('mobile-view', !isDesktop);
+    localStorage.setItem('mobileView', isDesktop ? 'desktop' : 'mobile');
     updateToggleButtons();
 }
 

--- a/tests/desktopToggle.test.js
+++ b/tests/desktopToggle.test.js
@@ -21,7 +21,7 @@ describe('toggleDesktopView', () => {
     window.close();
   });
 
-  test('toggles view classes', () => {
+  test('toggles view classes and saves state', () => {
     expect(document.body.classList.contains('desktop-view')).toBe(true);
     expect(document.body.classList.contains('mobile-view')).toBe(false);
     expect(window.localStorage.getItem('mobileView')).toBe(null);
@@ -30,12 +30,12 @@ describe('toggleDesktopView', () => {
 
     expect(document.body.classList.contains('desktop-view')).toBe(false);
     expect(document.body.classList.contains('mobile-view')).toBe(true);
-    expect(window.localStorage.getItem('mobileView')).toBe(null);
+    expect(window.localStorage.getItem('mobileView')).toBe('mobile');
 
     window.toggleDesktopView();
 
     expect(document.body.classList.contains('desktop-view')).toBe(true);
     expect(document.body.classList.contains('mobile-view')).toBe(false);
-    expect(window.localStorage.getItem('mobileView')).toBe(null);
+    expect(window.localStorage.getItem('mobileView')).toBe('desktop');
   });
 });

--- a/tests/mobileToggle.test.js
+++ b/tests/mobileToggle.test.js
@@ -21,7 +21,7 @@ describe('toggleMobileView', () => {
     window.close();
   });
 
-  test('toggles view classes', () => {
+  test('toggles view classes and saves state', () => {
     expect(document.body.classList.contains('mobile-view')).toBe(false);
     expect(document.body.classList.contains('desktop-view')).toBe(true);
     expect(window.localStorage.getItem('mobileView')).toBe(null);
@@ -30,12 +30,12 @@ describe('toggleMobileView', () => {
 
     expect(document.body.classList.contains('mobile-view')).toBe(true);
     expect(document.body.classList.contains('desktop-view')).toBe(false);
-    expect(window.localStorage.getItem('mobileView')).toBe(null);
+    expect(window.localStorage.getItem('mobileView')).toBe('mobile');
 
     window.toggleMobileView();
 
     expect(document.body.classList.contains('mobile-view')).toBe(false);
     expect(document.body.classList.contains('desktop-view')).toBe(true);
-    expect(window.localStorage.getItem('mobileView')).toBe(null);
+    expect(window.localStorage.getItem('mobileView')).toBe('desktop');
   });
 });

--- a/tests/mobileViewPersistence.test.js
+++ b/tests/mobileViewPersistence.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('mobile/desktop view persists after reload', () => {
+  let window, document, dom, scriptContent;
+
+  beforeAll(() => {
+    scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+  });
+
+  afterEach(() => {
+    if (dom) dom.window.close();
+  });
+
+  test('saved mobile class applied on reload', () => {
+    dom = new JSDOM('<body></body>', { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    window.toggleMobileView();
+    const stored = window.localStorage.getItem('mobileView');
+    dom.window.close();
+
+    dom = new JSDOM('<body></body>', { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+    const scriptEl2 = document.createElement('script');
+    scriptEl2.textContent = scriptContent;
+    document.body.appendChild(scriptEl2);
+    window.localStorage.setItem('mobileView', stored);
+
+    // allow DOMContentLoaded to fire
+    return new Promise(resolve => {
+      window.addEventListener('DOMContentLoaded', () => {
+        expect(document.body.classList.contains('mobile-view')).toBe(true);
+        expect(document.body.classList.contains('desktop-view')).toBe(false);
+        resolve();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- persist mobile/desktop view choice in `localStorage`
- update toggle functions to store the chosen view
- add tests covering persistence and updated toggle behaviour
- document mobile/desktop view persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb2ad2c948321ba6e6426b5b938a3