### PR TITLE
Add clipboard fallback and tests

### DIFF
--- a/script.js
+++ b/script.js
@@ -386,13 +386,45 @@ function createServiceButton(service, favoritesSet, categoryName) {
     copyBtn.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        navigator.clipboard.writeText(service.url).then(() => {
-            const original = copyBtn.textContent;
-            copyBtn.textContent = 'Copied!';
+
+        const original = copyBtn.textContent;
+        const showMessage = (msg) => {
+            copyBtn.textContent = msg;
             setTimeout(() => {
                 copyBtn.textContent = original;
             }, 1000);
-        });
+        };
+
+        const fallbackCopy = () => {
+            const textarea = document.createElement('textarea');
+            textarea.value = service.url;
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                const success = document.execCommand('copy');
+                document.body.removeChild(textarea);
+                if (success) {
+                    showMessage('Copied!');
+                } else {
+                    showMessage('Copy failed');
+                }
+            } catch (err) {
+                document.body.removeChild(textarea);
+                showMessage('Copy failed');
+            }
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(service.url)
+                .then(() => {
+                    showMessage('Copied!');
+                })
+                .catch(fallbackCopy);
+        } else {
+            fallbackCopy();
+        }
     });
     serviceUrlSpan.appendChild(copyBtn);
 

--- a/tests/copyFunctionality.test.js
+++ b/tests/copyFunctionality.test.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('copy button functionality', () => {
+  const servicesData = [
+    { name: 'Alpha', url: 'http://alpha.com', favicon_url: 'alpha.ico', category: 'Test' }
+  ];
+  let dom, window, document;
+
+  beforeEach(() => {
+    const html = '<main></main>';
+    dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost' });
+    window = dom.window;
+    document = window.document;
+    document.documentElement.style.setProperty('--category-max-height', '400px');
+
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+    const scriptEl = document.createElement('script');
+    scriptEl.textContent = scriptContent;
+    document.body.appendChild(scriptEl);
+
+    window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(servicesData) }));
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    jest.useRealTimers();
+  });
+
+  test('uses navigator.clipboard when available', async () => {
+    const writeMock = jest.fn(() => Promise.resolve());
+    window.navigator.clipboard = { writeText: writeMock };
+
+    await window.loadServices();
+
+    const copyBtn = document.querySelector('.copy-link');
+    jest.useFakeTimers();
+    copyBtn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(writeMock).toHaveBeenCalledWith('http://alpha.com');
+    expect(copyBtn.textContent).toBe('Copied!');
+    jest.advanceTimersByTime(1000);
+    expect(copyBtn.textContent).toBe('📋');
+  });
+
+  test('falls back to execCommand when clipboard API unavailable', async () => {
+    delete window.navigator.clipboard;
+    const execMock = jest.fn(() => true);
+    document.execCommand = execMock;
+
+    await window.loadServices();
+
+    const copyBtn = document.querySelector('.copy-link');
+    jest.useFakeTimers();
+    copyBtn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(execMock).toHaveBeenCalledWith('copy');
+    expect(copyBtn.textContent).toBe('Copied!');
+    jest.advanceTimersByTime(1000);
+    expect(copyBtn.textContent).toBe('📋');
+  });
+
+  test('shows error message when copy fails', async () => {
+    delete window.navigator.clipboard;
+    const execMock = jest.fn(() => false);
+    document.execCommand = execMock;
+
+    await window.loadServices();
+
+    const copyBtn = document.querySelector('.copy-link');
+    jest.useFakeTimers();
+    copyBtn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(execMock).toHaveBeenCalledWith('copy');
+    expect(copyBtn.textContent).toBe('Copy failed');
+    jest.advanceTimersByTime(1000);
+    expect(copyBtn.textContent).toBe('📋');
+  });
+});


### PR DESCRIPTION
## Summary
- improve copy button to fall back to `execCommand` when `navigator.clipboard` is unavailable
- show a `Copy failed` message if copying does not succeed
- test clipboard success path, fallback path, and failure display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb6746d3483219c315b5c2bb52476