### PR TITLE
Enable fuzzy search ranking

### DIFF
--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -104,4 +104,22 @@ describe('search filtering', () => {
 
     buttons.forEach(btn => expect(btn.style.display).toBe('none'));
   });
+
+  test('handles partial and fuzzy matches', () => {
+    const buttons = document.querySelectorAll('.service-button');
+    const [alphaBtn, betaBtn] = buttons;
+
+    searchInput.value = 'alp';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(alphaBtn.style.display).toBe('flex');
+    expect(betaBtn.style.display).toBe('none');
+
+    searchInput.value = 'ne';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(alphaBtn.style.display).toBe('flex');
+
+    searchInput.value = 'ne, cat';
+    searchInput.dispatchEvent(new window.Event('input', { bubbles: true }));
+    expect(alphaBtn.style.display).toBe('flex');
+  });
 });


### PR DESCRIPTION
## Summary
- implement fuzzyScore and apply to setupSearch
- sort search results by descending score
- test partial and fuzzy search behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc655f7048321aac42d8e18b3319d