### PR TITLE
Fix sidebar toggle positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -254,10 +254,6 @@ header {
     transition: left 0.3s ease;
 }
 
-#sidebar.open + header #sidebarToggle,
-#sidebar.open + #sidebarToggle {
-    left: calc(200px + 1rem);
-}
 
 body.sidebar-open header,
 body.sidebar-open main,


### PR DESCRIPTION
## Summary
- remove left-shift rule for `#sidebarToggle` when sidebar is open

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd51858ec832187ad08796933f416