### PR TITLE
Fix sidebar offset on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -263,6 +263,14 @@ body.sidebar-open footer {
     transition: margin-left 0.3s ease, width 0.3s ease;
 }
 
+/* Prevent layout shift on small screens when sidebar is open */
+body.mobile-view.sidebar-open header,
+body.mobile-view.sidebar-open main,
+body.mobile-view.sidebar-open footer {
+    margin-left: 0;
+    width: 100%;
+}
+
 #header-favicon {
     display: block;
     width: 50px;


### PR DESCRIPTION
## Summary
- keep default width shift when sidebar opens
- override sidebar shift in mobile view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd63bcaf8832187ff248b18b60821