### PR TITLE
Add toggle-button class and clean up styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,13 +24,13 @@
     <header>
         <img id="header-favicon" src="./public/favicon.ico" alt="AI Services Dashboard Favicon" />
         <h1 class="typing-effect">AI Services Dashboard</h1>
-        <button id="themeToggle" onclick="toggleTheme()" aria-label="Toggle theme" title="Toggle theme">
+        <button id="themeToggle" class="toggle-button" onclick="toggleTheme()" aria-label="Toggle theme" title="Toggle theme">
             <svg id="themeIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
         </button>
-        <button id="viewToggle" onclick="toggleView()" aria-label="Toggle category view" title="Toggle category view">
+        <button id="viewToggle" class="toggle-button" onclick="toggleView()" aria-label="Toggle category view" title="Toggle category view">
             <svg id="viewIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
         </button>
-        <button id="deviceToggle" onclick="toggleDeviceView()" aria-label="Toggle device view" title="Toggle device view">
+        <button id="deviceToggle" class="toggle-button" onclick="toggleDeviceView()" aria-label="Toggle device view" title="Toggle device view">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
         </button>
         <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>

--- a/styles.css
+++ b/styles.css
@@ -77,7 +77,7 @@ header {
     box-shadow: 0 0 10px rgba(102, 178, 102, 0.3);
 }
 
-#themeToggle {
+.toggle-button {
     background: none;
     border: 2px solid var(--text-color);
     color: var(--text-color);
@@ -88,6 +88,7 @@ header {
     cursor: pointer;
     margin-top: 1rem;
 }
+
 #themeToggle.active,
 #viewToggle.active,
 #deviceToggle.active {
@@ -96,28 +97,10 @@ header {
 }
 
 #viewToggle {
-    background: none;
-    border: 2px solid var(--text-color);
-    color: var(--text-color);
-    font-family: var(--font-family);
-    font-size: 0.8rem;
-    padding: 0.2rem 0.4rem;
-    border-radius: 5px;
-    cursor: pointer;
-    margin-top: 1rem;
     margin-left: 0.5rem;
 }
 
 #deviceToggle {
-    background: none;
-    border: 2px solid var(--text-color);
-    color: var(--text-color);
-    font-family: var(--font-family);
-    font-size: 0.8rem;
-    padding: 0.2rem 0.4rem;
-    border-radius: 5px;
-    cursor: pointer;
-    margin-top: 1rem;
     margin-left: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- consolidate shared button styles with a new `.toggle-button` class
- remove repeated styles from individual toggle buttons
- attach the new class to toggle buttons in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce4822f788321a1e3a1a87a4fd226