### PR TITLE
Fix service naming for Tabnine

### DIFF
--- a/services.json
+++ b/services.json
@@ -907,7 +907,7 @@
     ]
   },
   {
-    "name": "Codota",
+    "name": "Tabnine",
     "url": "https://www.tabnine.com/",
     "favicon_url": "https://www.tabnine.com/favicon.ico",
     "category": "💻 Coding and Development",


### PR DESCRIPTION
## Summary
- rename the Codota entry to Tabnine so the service name aligns with the URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf665fdbc8321a4a432030805c3ae