### PR TITLE
Add additional AI service links

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <header>
         <img id="header-favicon" src="./public/favicon.ico" alt="AI Services Dashboard Favicon" />
         <h1 class="typing-effect">AI Services Dashboard</h1>
+        <span id="totalServices" class="service-total"></span>
         <button id="themeToggle" class="toggle-button" onclick="toggleTheme()" aria-label="Dark theme active" title="Dark theme active">
             <svg id="themeIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
         </button>

--- a/script.js
+++ b/script.js
@@ -880,7 +880,8 @@ function buildSidebar() {
         if (!titleEl) return;
         const link = document.createElement('a');
         link.href = `#${section.id}`;
-        link.textContent = titleEl.textContent;
+        const plainText = titleEl.textContent.replace(/\(\d+\)$/, '').trim();
+        link.textContent = plainText;
         link.addEventListener('click', () => {
             toggleSidebar();
         });

--- a/script.js
+++ b/script.js
@@ -118,6 +118,10 @@ async function loadServices() {
         }
         const services = await response.json();
         allServices = services;
+        const totalEl = document.getElementById('totalServices');
+        if (totalEl) {
+            totalEl.textContent = `${services.length} services`;
+        }
         const mainContainer = document.querySelector('main');
 
         // Clear existing static categories if any (optional, if HTML is pre-populated)
@@ -167,7 +171,8 @@ async function loadServices() {
                 textContent = categoryName.substring(emojiMatch[0].length).trim();
             }
 
-            categoryHeader.innerHTML = `${emojiSpan}<span class="category-title">${textContent}</span> ${CHEVRON_SVG}<span class="category-view-toggle" role="button" tabindex="0" aria-label="Grid view active" title="Grid view active">☰</span>`;
+            const count = servicesInCategory.length;
+            categoryHeader.innerHTML = `${emojiSpan}<span class="category-title">${textContent}<span class="service-count">(${count})</span></span> ${CHEVRON_SVG}<span class="category-view-toggle" role="button" tabindex="0" aria-label="Grid view active" title="Grid view active">☰</span>`;
             const viewToggle = categoryHeader.querySelector('.category-view-toggle');
             viewToggle.title = 'Grid view active';
             viewToggle.setAttribute('aria-label', 'Grid view active');

--- a/services.json
+++ b/services.json
@@ -5858,5 +5858,68 @@
     "tags": [
       "allinone"
     ]
-  }
+  },
+{
+  "name": "OldPhoto.ai",
+  "url": "https://oldphoto.ai/",
+  "favicon_url": "https://oldphoto.ai/favicon.ico",
+  "category": "🎨 Image Generation and Design",
+  "tags": [
+    "image"
+  ]
+},
+{
+  "name": "PS2AI",
+  "url": "https://ps2ai.com/",
+  "favicon_url": "https://ps2ai.com/favicon.ico",
+  "category": "🎨 Image Generation and Design",
+  "tags": [
+    "image"
+  ]
+},
+{
+  "name": "Azure OpenAI Service for Government (IL6)",
+  "url": "https://devblogs.microsoft.com/azuregov/azure-openai-authorization/",
+  "favicon_url": "https://azure.microsoft.com/favicon.ico",
+  "category": "🧠 Machine Learning Platforms",
+  "tags": [
+    "machinelearning"
+  ]
+},
+{
+  "name": "Azure AI Foundry",
+  "url": "https://azure.microsoft.com/en-us/solutions/ai/foundry",
+  "favicon_url": "https://azure.microsoft.com/favicon.ico",
+  "category": "🧠 Machine Learning Platforms",
+  "tags": [
+    "machinelearning"
+  ]
+},
+{
+  "name": "Microsoft Entra Verified ID",
+  "url": "https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-verified-id",
+  "favicon_url": "https://www.microsoft.com/favicon.ico",
+  "category": "🤖 Specialized",
+  "tags": [
+    "specialized"
+  ]
+},
+{
+  "name": "Microsoft Copilot Studio",
+  "url": "https://www.microsoft.com/en-us/microsoft-copilot/microsoft-copilot-studio",
+  "favicon_url": "https://www.microsoft.com/favicon.ico",
+  "category": "🤖 Specialized",
+  "tags": [
+    "specialized"
+  ]
+},
+{
+  "name": "Microsoft Dynamics 365 Copilot",
+  "url": "https://www.microsoft.com/en-us/dynamics-365/solutions/ai",
+  "favicon_url": "https://www.microsoft.com/favicon.ico",
+  "category": "🤖 Specialized",
+  "tags": [
+    "specialized"
+  ]
+}
 ]

--- a/styles.css
+++ b/styles.css
@@ -265,6 +265,12 @@ header h1 {
     animation: blink 0.7s infinite;
 }
 
+.service-total {
+    display: block;
+    font-size: 1rem;
+    margin-top: 0.25rem;
+}
+
 @keyframes blink {
     50% { opacity: 0; }
 }
@@ -397,6 +403,12 @@ body.block-view .category {
 .category-title {
     flex: 1;
     text-align: center;
+}
+
+.service-count {
+    margin-left: 0.25rem;
+    font-size: 0.9rem;
+    color: var(--accent-color);
 }
 
 .category-emoji {


### PR DESCRIPTION
## Summary
- add new AI service entries (e.g., OldPhoto.ai, PS2AI, Azure AI Foundry)
- show service totals per category and overall

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('services.json'))"`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d13a1fb088321889f0f37876db505