### PR TITLE
Update sidebar test counts

### DIFF
--- a/script.js
+++ b/script.js
@@ -875,7 +875,10 @@ function buildSidebar() {
         if (!titleEl) return;
         const link = document.createElement('a');
         link.href = `#${section.id}`;
-        link.textContent = titleEl.textContent;
+        const count = section.querySelectorAll('.service-button').length;
+        link.textContent = section.id === 'favorites'
+            ? titleEl.textContent
+            : `${titleEl.textContent}(${count})`;
         link.addEventListener('click', () => {
             toggleSidebar();
         });

--- a/tests/sidebar.test.js
+++ b/tests/sidebar.test.js
@@ -37,9 +37,9 @@ describe('sidebar navigation', () => {
     expect(links[0].getAttribute('href')).toBe('#favorites');
     expect(links[0].textContent).toBe('Favorites');
     expect(links[1].getAttribute('href')).toBe('#alpha');
-    expect(links[1].textContent).toBe('Alpha');
+    expect(links[1].textContent).toBe('Alpha(1)');
     expect(links[2].getAttribute('href')).toBe('#beta');
-    expect(links[2].textContent).toBe('Beta');
+    expect(links[2].textContent).toBe('Beta(1)');
     expect(links[3].getAttribute('href')).toBe('https://www.github.com/NathanNeurotic/AI');
   });
 


### PR DESCRIPTION
## Summary
- update sidebar navigation test to expect category counts
- display category counts in sidebar links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d18dce85c832186dba5cc236b1d5f