### PR TITLE
Improve theme preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The AI Services Dashboard is a static webpage designed to provide a curated list
     *   Header text wraps correctly on narrow screens.
     *   Interactive elements are properly handled in collapsed sections on mobile.
 *   **Persistent Category State:** Remembers which categories were left open or closed across sessions using browser localStorage.
-*   **Themed Interface:** Retro-terminal aesthetic with a typing effect in the header.
+*   **Themed Interface:** Retro-terminal aesthetic with a typing effect in the header. On first visit, the page follows your operating system's light or dark preference.
 *   **Service Counts:** The header shows the total number of available services, and each category title displays how many entries it contains.
 *   **Alphabetical Sorting:** Categories and services are automatically sorted alphabetically when `script.js` dynamically loads `services.json`.
 *   **Favorites:** Mark services with the star icon to quickly access them in a dedicated "Favorites" category that persists using `localStorage`.
@@ -144,7 +144,7 @@ Service data is stored in `services.json`. To add a new service or update an exi
 *   All custom styles are in `styles.css`.
 *   You can modify colors, fonts, spacing, layout, and other visual aspects by editing this file.
 *   The styles are generally organized by element or component (e.g., `header`, `category`, `service-button`).
-*   A built-in theme switcher toggles the `light-mode` class on `<body>` using `script.js` and remembers your choice in `localStorage`. Customize the default colors by changing the CSS variables defined at the top of `styles.css`.
+*   A built-in theme switcher toggles the `light-mode` class on `<body>` using `script.js` and remembers your choice in `localStorage`. If no theme is stored, the page defaults to your OS preference. Customize the default colors by changing the CSS variables defined at the top of `styles.css`.
 
 ### Modifying Functionality
 

--- a/script.js
+++ b/script.js
@@ -774,7 +774,9 @@ function renderFavoritesCategory() {
 
 function applySavedTheme() {
     const saved = localStorage.getItem('theme');
-    if (saved === 'light') {
+    const osPrefersLight = window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: light)').matches;
+    if (saved === 'light' || (saved === null && osPrefersLight)) {
         document.body.classList.add('light-mode');
         document.documentElement.classList.add('light-mode');
     }

--- a/tests/themePreference.test.js
+++ b/tests/themePreference.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+
+function setup(osLight) {
+  const dom = new JSDOM('<body></body>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const { window } = dom;
+  const { document } = window;
+  document.documentElement.style.setProperty('--category-max-height', '400px');
+  window.matchMedia = jest.fn().mockImplementation(query => ({
+    matches: osLight && query === '(prefers-color-scheme: light)',
+    media: query,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  }));
+  const scriptEl = document.createElement('script');
+  scriptEl.textContent = scriptContent;
+  document.body.appendChild(scriptEl);
+  return { window, document, dom };
+}
+
+describe('applySavedTheme respects OS preference', () => {
+  test('defaults to light mode if OS prefers light', () => {
+    const { window, document, dom } = setup(true);
+    window.applySavedTheme();
+    expect(document.body.classList.contains('light-mode')).toBe(true);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(true);
+    dom.window.close();
+  });
+
+  test('stays dark if OS prefers dark', () => {
+    const { window, document, dom } = setup(false);
+    window.applySavedTheme();
+    expect(document.body.classList.contains('light-mode')).toBe(false);
+    expect(document.documentElement.classList.contains('light-mode')).toBe(false);
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- detect OS light mode when applying saved theme
- note OS preference behavior in README
- add tests for OS theme preference

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d1e578354832186f4b4b3657b02ff