### PR TITLE
Add Google Translate widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
         </button>
         <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
+        <div id="google_translate_element" class="translate-widget"></div>
     </header>
     <main>
         <div class="search-container">
@@ -56,5 +57,14 @@
         New version available <button id="refreshBtn" title="Refresh to update">Refresh</button>
     </div>
     <script src="./script.js"></script>
+    <script>
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement(
+          {pageLanguage: 'en'},
+          'google_translate_element'
+        );
+      }
+    </script>
+    <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -127,6 +127,12 @@ header {
     display: none;
 }
 
+.translate-widget {
+    display: inline-block;
+    margin-left: 0.5rem;
+    font-size: 0.8rem;
+}
+
 #expandAllBtn,
 #collapseAllBtn {
     background: none;


### PR DESCRIPTION
## Summary
- integrate Google Translate widget in the header
- load translation script before the closing `body`
- style the widget alongside existing buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e47317f648321a52423c6b444c7c6