### PR TITLE
Fix language toggle alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -128,9 +128,27 @@ header {
 }
 
 .translate-widget {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     margin-left: 0.5rem;
+    vertical-align: middle;
     font-size: 0.8rem;
+}
+
+.translate-widget select {
+    background: none;
+    border: 2px solid var(--text-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: 0.8rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+body.mobile-view .translate-widget select {
+    font-size: 0.6rem;
+    padding: 0.1rem 0.2rem;
 }
 
 #expandAllBtn,


### PR DESCRIPTION
## Summary
- align the Google Translate dropdown with header controls
- style the dropdown to match buttons and shrink on mobile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e4c36541083219946a99e595df555