### PR TITLE
Improve styling consistency and category sorting

### DIFF
--- a/script.js
+++ b/script.js
@@ -166,7 +166,12 @@ async function loadServices() {
         }, {});
 
         // Generate HTML for categories and services in alphabetical order
-        const normalize = (name) => name.replace(/^(\p{Emoji_Presentation}|\p{Emoji})\s*/u, '').trim().toLowerCase();
+        const normalize = (name) =>
+            name
+                .replace(/[\p{Emoji_Presentation}\p{Emoji}]/gu, '')
+                .replace(/[^\p{L}\p{N}]+/gu, ' ')
+                .trim()
+                .toLowerCase();
         const sortedCategoryNames = Object.keys(categories).sort((a, b) => normalize(a).localeCompare(normalize(b)));
         for (const categoryName of sortedCategoryNames) {
             const servicesInCategory = categories[categoryName];

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,9 @@
     --accent-color: #5faa6f;
     --header-gradient: linear-gradient(180deg, #0a0a0a, #1a2a1a);
     --section-gradient: linear-gradient(90deg, #0a0a0a, #1a2a1a);
+    --category-header-gradient: linear-gradient(90deg, #1a2a1a, #274627);
+    --list-item-bg1: rgba(60, 90, 60, 0.4);
+    --list-item-bg2: rgba(50, 80, 50, 0.4);
     --content-bg: rgba(42, 42, 42, 0.7);
     --button-gradient: linear-gradient(135deg, rgba(20, 20, 20, 0.9), rgba(40, 60, 40, 0.9));
     --footer-gradient: linear-gradient(180deg, #1a2a1a, #0a0a0a);
@@ -36,6 +39,9 @@ body.light-mode {
     --accent-color: #007acc;
     --header-gradient: linear-gradient(180deg, #ffffff 0%, #dfe9ff 100%);
     --section-gradient: linear-gradient(90deg, #f8fbff 0%, #e0ecff 100%);
+    --category-header-gradient: linear-gradient(90deg, #e0ffe0 0%, #ccffcc 100%);
+    --list-item-bg1: rgba(210, 245, 210, 0.8);
+    --list-item-bg2: rgba(190, 235, 190, 0.8);
     --content-bg: rgba(255, 255, 255, 0.85);
     --button-gradient: linear-gradient(135deg, #ffffff 0%, #e6f3ff 100%);
     --footer-gradient: linear-gradient(180deg, #e0ecff 0%, #ffffff 100%);
@@ -288,7 +294,7 @@ body.mobile-view.sidebar-open footer {
 }
 
 header h1 {
-    font-size: 2.5rem;
+    font-size: 1.6rem;
     margin: 0;
     text-transform: uppercase;
     letter-spacing: 3px;
@@ -391,12 +397,12 @@ body.block-view .category {
 }
 
 .category h2 {
-    background: var(--section-gradient);
+    background: var(--category-header-gradient);
     padding: 0.85rem;
     padding-right: calc(1rem + var(--scrollbar-width));
     margin: 0;
     cursor: pointer;
-    font-size: 1.6rem;
+    font-size: 1.2rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -537,6 +543,14 @@ body.block-view .category {
     backdrop-filter: blur(4px);
     transform: translateY(-2px);
     animation: none;
+}
+
+.category-content .service-button:nth-child(odd) {
+    background: var(--list-item-bg1);
+}
+
+.category-content .service-button:nth-child(even) {
+    background: var(--list-item-bg2);
 }
 
 @keyframes pulse {
@@ -685,13 +699,6 @@ body.desktop-view .category-content {
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
 }
 
-body.mobile-view header h1 {
-    font-size: 1.6rem;
-}
-
-body.mobile-view .category h2 {
-    font-size: 1.2rem;
-}
 
 body.mobile-view #searchInput {
     width: 90%;


### PR DESCRIPTION
## Summary
- tweak header and category font sizes for cross-device consistency
- add new CSS vars for category and list item colors
- alternate list item backgrounds with green tones
- brighten category header backgrounds
- make category sorting more robust when removing emoji/punctuation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e50a61e708321aa70f820a638cf05