### PR TITLE
Fix Google Translate widget overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,10 @@
     <script>
       function googleTranslateElementInit() {
         new google.translate.TranslateElement(
-          {pageLanguage: 'en'},
+          {
+            pageLanguage: 'en',
+            layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+          },
           'google_translate_element'
         );
       }

--- a/styles.css
+++ b/styles.css
@@ -139,7 +139,7 @@ header {
     align-items: center;
     vertical-align: middle;
     font-size: 0.7rem;
-    position: fixed;
+    position: absolute;
     top: 0.5rem;
     right: 0.5rem;
     margin-left: 0;
@@ -155,6 +155,17 @@ header {
     padding: 0.05rem 0.15rem;
     border-radius: 5px;
     cursor: pointer;
+}
+
+/* Hide default Google banner and shrink dropdown */
+.goog-te-banner-frame.skiptranslate {
+    display: none !important;
+}
+body {
+    top: 0 !important;
+}
+.goog-te-combo {
+    font-size: 0.5rem !important;
 }
 
 body.mobile-view .translate-widget select {


### PR DESCRIPTION
## Summary
- keep the Google Translate dropdown compact and inside the header
- hide the default banner
- ensure translator uses SIMPLE layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f2ab7ae38832195d009ddc4cfddca