### PR TITLE
Add CSS rules to reduce translate widget size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -144,6 +144,8 @@ header {
     right: 0.5rem;
     margin-left: 0;
     z-index: 1000;
+    transform: scale(0.8); /* shrink Google Translate widget */
+    transform-origin: top right;
 }
 
 .translate-widget select {
@@ -166,6 +168,7 @@ body {
 }
 .goog-te-combo {
     font-size: 0.5rem !important;
+    width: 4.5rem !important; /* reduce dropdown width */
 }
 
 body.mobile-view .translate-widget select {


### PR DESCRIPTION
## Summary
- shrink Google Translate widget
- limit width of dropdown

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2dcf5a3c83219df6dfbdfe324700