### PR TITLE
Add custom language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,11 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
         </button>
         <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
-        <div id="google_translate_element" class="translate-widget"></div>
+        <div class="translate-widget">
+            <select id="languageSelect" aria-label="Select language"></select>
+        </div>
     </header>
+    <div id="google_translate_element" style="display: none"></div>
     <main>
         <div class="search-container">
             <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" list="tagOptions" />
@@ -57,17 +60,6 @@
         New version available <button id="refreshBtn" title="Refresh to update">Refresh</button>
     </div>
     <script src="./script.js"></script>
-    <script>
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement(
-          {
-            pageLanguage: 'en',
-            layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
-          },
-          'google_translate_element'
-        );
-      }
-    </script>
     <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1007,3 +1007,39 @@ window.collapseAllCategories = collapseAllCategories;
 window.clearSearch = clearSearch;
 window.setupSidebarHighlighting = setupSidebarHighlighting;
 
+/* global google */
+
+function setupLanguageSelect() {
+    const googleSelect = document.querySelector('#google_translate_element .goog-te-combo');
+    const customSelect = document.getElementById('languageSelect');
+    if (!googleSelect || !customSelect) {
+        return;
+    }
+    if (googleSelect.options.length === 0) {
+        setTimeout(setupLanguageSelect, 50);
+        return;
+    }
+    customSelect.innerHTML = '';
+    Array.from(googleSelect.options).forEach(opt => {
+        customSelect.appendChild(opt.cloneNode(true));
+    });
+    customSelect.value = googleSelect.value;
+    customSelect.addEventListener('change', () => {
+        googleSelect.value = customSelect.value;
+        googleSelect.dispatchEvent(new Event('change'));
+    });
+}
+
+function googleTranslateElementInit() {
+    new google.translate.TranslateElement(
+        {
+            pageLanguage: 'en',
+            layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+        },
+        'google_translate_element'
+    );
+    setupLanguageSelect();
+}
+
+window.googleTranslateElementInit = googleTranslateElementInit;
+

--- a/styles.css
+++ b/styles.css
@@ -144,8 +144,6 @@ header {
     right: 0.5rem;
     margin-left: 0;
     z-index: 1000;
-    transform: scale(0.8); /* shrink Google Translate widget */
-    transform-origin: top right;
 }
 
 .translate-widget select {
@@ -154,6 +152,7 @@ header {
     color: var(--text-color);
     font-family: var(--font-family);
     font-size: 0.5rem;
+    width: 4.5rem;
     padding: 0.05rem 0.15rem;
     border-radius: 5px;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add custom language dropdown
- copy Google Translate options into dropdown
- hide Google-provided widget
- style new selector without `transform`
- move translation script into `script.js`

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f3326810c8321b56c21fe236a061f