### PR TITLE
Update translation widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,11 +35,8 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
         </button>
         <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
-        <div class="translate-widget">
-            <select id="languageSelect" aria-label="Select language"></select>
-        </div>
     </header>
-    <div id="google_translate_element" style="display: none"></div>
+    <div id="google_translate_element"></div>
     <main>
         <div class="search-container">
             <input id="searchInput" type="text" placeholder="Search services..." aria-label="Search AI services" list="tagOptions" />
@@ -61,27 +58,6 @@
     </div>
     <script src="./script.js"></script>
     <script>
-      function setupLanguageSelect() {
-        const googleSelect = document.querySelector('#google_translate_element .goog-te-combo');
-        const customSelect = document.getElementById('languageSelect');
-        if (!googleSelect || !customSelect) {
-          return;
-        }
-        if (googleSelect.options.length === 0) {
-          setTimeout(setupLanguageSelect, 50);
-          return;
-        }
-        customSelect.innerHTML = '';
-        Array.from(googleSelect.options).forEach(opt => {
-          customSelect.appendChild(opt.cloneNode(true));
-        });
-        customSelect.value = googleSelect.value;
-        customSelect.addEventListener('change', () => {
-          googleSelect.value = customSelect.value;
-          googleSelect.dispatchEvent(new Event('change'));
-        });
-      }
-
       function googleTranslateElementInit() {
         new google.translate.TranslateElement(
           {
@@ -90,7 +66,6 @@
           },
           'google_translate_element'
         );
-        setupLanguageSelect();
       }
     </script>
     <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>

--- a/styles.css
+++ b/styles.css
@@ -134,29 +134,7 @@ header {
     display: none;
 }
 
-.translate-widget {
-    display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
-    font-size: 0.7rem;
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    margin-left: 0;
-    z-index: 1000;
-}
 
-.translate-widget select {
-    background: none;
-    border: 2px solid var(--text-color);
-    color: var(--text-color);
-    font-family: var(--font-family);
-    font-size: 0.5rem;
-    width: 4.5rem;
-    padding: 0.05rem 0.15rem;
-    border-radius: 5px;
-    cursor: pointer;
-}
 
 /* Hide default Google banner and shrink dropdown */
 .goog-te-banner-frame.skiptranslate {
@@ -166,14 +144,22 @@ body {
     top: 0 !important;
 }
 .goog-te-combo {
+    background: none;
+    border: 2px solid var(--text-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
     font-size: 0.5rem !important;
     width: 4.5rem !important; /* reduce dropdown width */
+    padding: 0.05rem 0.15rem;
+    border-radius: 5px;
+    cursor: pointer;
 }
 
-body.mobile-view .translate-widget select {
+body.mobile-view .goog-te-combo {
     font-size: 0.45rem;
     padding: 0.05rem 0.15rem;
 }
+
 
 #expandAllBtn,
 #collapseAllBtn {

--- a/tests/translation.test.js
+++ b/tests/translation.test.js
@@ -33,24 +33,23 @@ describe('google translate dropdown', () => {
     dom.window.close();
   });
 
-  test('dropdown populated after init', () => {
-    const customSelect = document.getElementById('languageSelect');
-    expect(customSelect.options.length).toBe(0);
+  test('google widget populated after init', () => {
+    const container = document.getElementById('google_translate_element');
+    expect(container.querySelector('.goog-te-combo')).toBeNull();
 
     window.googleTranslateElementInit();
 
-    expect(customSelect.options.length).toBe(2);
-    const googleSelect = document.querySelector('#google_translate_element .goog-te-combo');
+    const googleSelect = container.querySelector('.goog-te-combo');
     expect(googleSelect).not.toBeNull();
+    expect(googleSelect.options.length).toBe(2);
   });
 
-  test('selecting language updates google widget', () => {
+  test('selecting language updates value', () => {
     window.googleTranslateElementInit();
-    const customSelect = document.getElementById('languageSelect');
     const googleSelect = document.querySelector('#google_translate_element .goog-te-combo');
 
-    customSelect.value = 'es';
-    customSelect.dispatchEvent(new window.Event('change'));
+    googleSelect.value = 'es';
+    googleSelect.dispatchEvent(new window.Event('change'));
 
     expect(googleSelect.value).toBe('es');
   });


### PR DESCRIPTION
## Summary
- remove custom translation dropdown and expose Google widget
- clean up translation widget CSS
- update translation tests for default Google widget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f397a95c48321903e7bc62468f538