### PR TITLE
Jules

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,27 +28,33 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const installBtn = document.getElementById('installBtn');
     if (installBtn) {
+        console.log('Attempting to set installBtn style to none initially.');
         installBtn.style.display = 'none';
+        console.log('Install button initial display set to:', installBtn.style.display);
         installBtn.addEventListener('click', async () => {
             if (!deferredPrompt) return;
             deferredPrompt.prompt();
             await deferredPrompt.userChoice;
             deferredPrompt = null;
             installBtn.style.display = 'none';
+            console.log('Install button display set to: none - prompt dismissed');
         });
     }
 
     window.addEventListener('beforeinstallprompt', (e) => {
+        console.log('beforeinstallprompt event fired');
         e.preventDefault();
         deferredPrompt = e;
         if (installBtn) {
             installBtn.style.display = 'inline-block';
+            console.log('Install button display set to: inline-block');
         }
     });
 
     window.addEventListener('appinstalled', () => {
         if (installBtn) {
             installBtn.style.display = 'none';
+            console.log('Install button display set to: none - app installed');
         }
         deferredPrompt = null;
     });

--- a/styles.css
+++ b/styles.css
@@ -131,7 +131,6 @@ header {
     cursor: pointer;
     margin-top: 1rem;
     margin-left: 0.5rem;
-    display: none;
 }
 
 
@@ -159,20 +158,27 @@ body {
     border: 2px solid var(--text-color);
     color: var(--text-color);
     font-family: var(--font-family);
-    font-size: 0.55rem !important;
-    width: 5rem !important;
-    padding: 0.05rem 0.15rem;
+    font-size: 0.5rem;
+    width: 4rem;
+    padding: 0.1rem 0.2rem;
     border-radius: 5px;
     cursor: pointer;
 }
 
 body.mobile-view #google_translate_element .goog-te-combo {
-    font-size: 0.5rem;
-    padding: 0.05rem 0.15rem;
+    font-size: 0.5rem; /* Consistent with the general rule */
+    padding: 0.1rem 0.2rem; /* Consistent with the general rule */
+}
+
+#google_translate_element .goog-te-combo:hover,
+#google_translate_element .goog-te-combo:focus {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-color: var(--accent-color);
+    box-shadow: 0 0 8px rgba(95, 170, 111, 0.4);
 }
 
 .goog-te-menu-frame {
-    transform: scale(0.85);
+    transform: scale(0.8);
     transform-origin: top left;
 }
 


### PR DESCRIPTION
Fix: Address Install App and Google Translate button UI issues

This commit resolves several UI problems related to the Install App button and the Google Translate widget.

Install App Button:
- Added console logging to `script.js` to better track the `beforeinstallprompt` event and the dynamic changes to the button's visibility.
- Removed the `display: none;` style from `#installBtn` in `styles.css`. The button's visibility is now solely managed by JavaScript, which should prevent CSS conflicts if the `beforeinstallprompt` event fires correctly.

Google Translate Button:
- Sizing: Reduced the overall size of the translate button.
    - Removed `!important` from `width` and `font-size` properties for `.goog-te-combo`.
    - Adjusted `width` to `4rem` (from `5rem`), `font-size` to `0.5rem` (from `0.55rem`), and updated padding for better proportion.
- Theming: Improved visual consistency with other site buttons.
    - Added `:hover` and `:focus` styles to `.goog-te-combo` to include a subtle background change, accent border color, and box shadow, mirroring the behavior of other interactive elements.
- Submenu Width: Reduced the width of the translate dropdown menu.
    - Modified the `transform: scale()` for `.goog-te-menu-frame` from `0.85` to `0.8` to make the submenu less wide.

These changes aim to improve your experience by ensuring the install button appears when appropriate and by making the Google Translate widget less obtrusive and better integrated into the site's design.