### PR TITLE
Jules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -143,13 +143,13 @@ body {
     top: 0 !important;
 }
 .goog-te-gadget {
-    font-size: 0; /* hide default label text */
+    font-size: 1px; /* hide default label text */
 }
 
 #google_translate_element {
     position: absolute;
-    top: 1.5rem;
-    right: 1.5rem;
+    top: 0.5rem;
+    right: 0.5rem;
     margin: 0;
     z-index: 1200;
     display: flex; /* Kept to allow alignment if needed, though with absolute positioning it might be less relevant */


### PR DESCRIPTION
Fix: Adjust Google Translate widget style to prevent overlap

The Google Translate widget's text was reportedly too large and overlapped the header logo. Additionally, it was too indented from the top-right corner.

This commit addresses these issues by:
1. Modifying the `styles.css` for the `#google_translate_element`:
    - Changed `top` and `right` properties from `1.5rem` to `0.5rem`. This moves the widget to be more flush with the top-right corner of the header.
2. Modifying the `styles.css` for the `.goog-te-gadget` container:
    - Changed `font-size` from `0` to `1px`. This ensures that any text within the gadget (like the "Powered by" attribution or other labels Google might inject) is rendered at a practically invisible size, preventing it from being large and causing layout overlaps. The select dropdown itself maintains its specific `0.5rem` font size.

These changes should ensure the widget is correctly positioned and does not interfere with other header elements.