### PR TITLE
Remove 'Powered by' text from translate branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,13 @@
           },
           'google_translate_element'
         );
+        const interval = setInterval(() => {
+          const logo = document.querySelector('.goog-logo-link');
+          if (logo) {
+            logo.textContent = logo.textContent.replace('Powered by', '').trim();
+            clearInterval(interval);
+          }
+        }, 100);
       }
     </script>
     <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>


### PR DESCRIPTION
## Summary
- remove the 'Powered by' prefix from the Google Translate branding

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f62ccdd2883218dd7ec4aa9181ea5