### PR TITLE
Shrink Google Translate branding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -802,7 +802,7 @@ body.mobile-view #viewToggle {
 #google_translate_element .goog-logo-link,
 #google_translate_element .goog-logo-link:link,
 #google_translate_element .goog-logo-link:visited {
-    /* font-size: inherit; */ /* Or a specific small but legible size like 0.8em or 10px */
+    font-size: 0.5em; /* Shrink branding text for better header fit */
     /* color: inherit; */ /* Or your desired link color */
     /* No special styling needed here if the default/inherited styles are okay after removing .goog-te-gadget rule */
 }


### PR DESCRIPTION
## Summary
- shrink Google Translate branding text for better header fit

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f82f62a6c832192846a45cd180bf7