### PR TITLE
Reduce Google branding size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -802,7 +802,7 @@ body.mobile-view #viewToggle {
 #google_translate_element .goog-logo-link,
 #google_translate_element .goog-logo-link:link,
 #google_translate_element .goog-logo-link:visited {
-    font-size: 0.5em; /* Shrink branding text for better header fit */
+    font-size: 0.25em !important; /* Further reduce Google branding size */
     /* color: inherit; */ /* Or your desired link color */
     /* No special styling needed here if the default/inherited styles are okay after removing .goog-te-gadget rule */
 }


### PR DESCRIPTION
## Summary
- scale down the Google branding text under the translation dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f863bcc7c83219050e962be12fd43