### PR TITLE
Wrap Google branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,11 +73,15 @@
       const observer = new MutationObserver((mutationsList, obs) => {
         const logoLink = translateElement.querySelector('.goog-logo-link');
 
-        if (logoLink) {
-          // Inline style ensures the branding is visibly scaled down
-          logoLink.style.transform = 'scale(0.5)';
-          logoLink.style.transformOrigin = 'left top';
-          logoLink.style.display = 'inline-block';
+        if (logoLink && !logoLink.closest('.branding-wrapper')) {
+          const wrapper = document.createElement('span');
+          wrapper.className = 'branding-wrapper';
+          wrapper.setAttribute(
+            'style',
+            'display:inline-block; transform:scale(0.5); transform-origin:left top;'
+          );
+          logoLink.parentNode.insertBefore(wrapper, logoLink);
+          wrapper.appendChild(logoLink);
         }
 
         // Check if the logo link exists and hasn't been processed yet

--- a/styles.css
+++ b/styles.css
@@ -803,9 +803,6 @@ body.mobile-view #viewToggle {
 #google_translate_element .goog-logo-link:link,
 #google_translate_element .goog-logo-link:visited {
     font-size: 0.25em !important; /* Further reduce Google branding size */
-    display: inline-block; /* Required for transform scaling */
-    transform: scale(0.5); /* Shrink entire branding line */
-    transform-origin: left top;
     /* color: inherit; */ /* Or your desired link color */
-    /* No special styling needed here if the default/inherited styles are okay after removing .goog-te-gadget rule */
+    /* The branding wrapper handles scaling */
 }


### PR DESCRIPTION
## Summary
- add wrapper in MutationObserver to scale Google branding
- remove direct transform on `.goog-logo-link`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f8ab8a3ac83218931a68946c264fe