### PR TITLE
Fix translation dropdown position

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
         <button id="deviceToggle" class="toggle-button" onclick="toggleDeviceView()" aria-label="Desktop view active" title="Desktop view active">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
         </button>
-        <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
         <div id="google_translate_element"></div>
+        <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
     </header>
     <main>
         <div class="search-container">

--- a/styles.css
+++ b/styles.css
@@ -149,14 +149,10 @@ body {
 */
 
 #google_translate_element {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    margin: 0;
-    z-index: 1200;
-    display: flex; /* Kept to allow alignment if needed, though with absolute positioning it might be less relevant */
-    flex-direction: column; /* Kept for consistency, might be removed if not needed */
-    align-items: flex-start; /* Kept for consistency */
+    margin: 0.5rem auto 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 #google_translate_element .goog-te-combo {


### PR DESCRIPTION
## Summary
- center the Google Translate dropdown underneath header buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f8bf55ba08321bbde2841d9bbd89b