### PR TITLE
Fix translation dropdown position

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -149,14 +149,10 @@ body {
 */
 
 #google_translate_element {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    margin: 0;
-    z-index: 1200;
-    display: flex; /* Kept to allow alignment if needed, though with absolute positioning it might be less relevant */
-    flex-direction: column; /* Kept for consistency, might be removed if not needed */
-    align-items: flex-start; /* Kept for consistency */
+    margin: 0.5rem auto 0;
+    display: flex;
+    justify-content: center;
+    width: 100%;
 }
 
 #google_translate_element .goog-te-combo {


### PR DESCRIPTION
## Summary
- position the Google Translate dropdown after the header buttons
- use flex styling to center it on its own line below the controls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8bf55ba08321bbde2841d9bbd89b