### PR TITLE
Fix layout when Google Translate toolbar appears

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,19 @@
       });
 
       observer.observe(translateElement, { childList: true, subtree: true });
+
+      const checkToolbar = () => {
+        const banner = document.querySelector('.goog-te-banner-frame');
+        if (banner) {
+          document.body.classList.add('translate-bar-active');
+        } else {
+          document.body.classList.remove('translate-bar-active');
+        }
+      };
+
+      const toolbarObserver = new MutationObserver(checkToolbar);
+      toolbarObserver.observe(document.documentElement, { childList: true, subtree: true });
+      checkToolbar();
     }
   }
 </script>

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,7 @@
     --card-min-width: 300px;
     --card-max-width: 400px;
     --category-min-width: 300px;
+    --translate-bar-height: 40px;
 }
 
 body {
@@ -298,6 +299,19 @@ body.sidebar-open footer {
     margin-left: 200px;
     width: calc(100% - 200px);
     transition: margin-left 0.3s ease, width 0.3s ease;
+}
+
+/* Offset elements when Google Translate toolbar is visible */
+body.translate-bar-active header {
+    margin-top: var(--translate-bar-height);
+}
+
+body.translate-bar-active #sidebarToggle {
+    top: calc(1rem + var(--translate-bar-height));
+}
+
+body.translate-bar-active #sidebar {
+    top: var(--translate-bar-height);
 }
 
 /* Prevent layout shift on small screens when sidebar is open */

--- a/tests/translation.test.js
+++ b/tests/translation.test.js
@@ -54,4 +54,20 @@ describe('google translate dropdown', () => {
     expect(googleSelect.value).toBe('es');
   });
 
+  test('adds class when toolbar appears', done => {
+    window.googleTranslateElementInit();
+    const frame = document.createElement('iframe');
+    frame.className = 'goog-te-banner-frame';
+    document.documentElement.appendChild(frame);
+
+    setTimeout(() => {
+      expect(document.body.classList.contains('translate-bar-active')).toBe(true);
+      frame.remove();
+      setTimeout(() => {
+        expect(document.body.classList.contains('translate-bar-active')).toBe(false);
+        done();
+      }, 0);
+    }, 0);
+  });
+
 });


### PR DESCRIPTION
## Summary
- add CSS variable for the Google toolbar height
- offset header, sidebar, and toggle if the toolbar is present
- watch for Translate toolbar in `googleTranslateElementInit`
- test class toggling when the toolbar is inserted

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f9f76457083219ce9d454a553a1a1